### PR TITLE
Update external scripts to https

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,7 +8,7 @@ googleAnalytics = ""
 
 # Define the number of posts per page
 paginate = 10
-theme = "universal"
+theme = "hugo-universal-theme"
 
 [params]
     author = "DevCows"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,11 +15,11 @@
 
   {{ .Hugo.Generator }}
 
-  <link href='http://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 
   <!-- Bootstrap and Font Awesome css -->
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
 
   <!-- Css animations  -->
   <link href="{{ .Site.BaseURL }}css/animate.css" rel="stylesheet">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,11 +15,11 @@
 
   {{ .Hugo.Generator }}
 
-  <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 
   <!-- Bootstrap and Font Awesome css -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
 
   <!-- Css animations  -->
   <link href="{{ .Site.BaseURL }}css/animate.css" rel="stylesheet">

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,8 +1,8 @@
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script>
     window.jQuery || document.write('<script src="{{ .Site.BaseURL }}js/jquery-1.11.0.min.js"><\/script>')
 </script>
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 
 <script src="{{ .Site.BaseURL }}js/jquery.cookie.js"></script>
 <script src="{{ .Site.BaseURL }}js/waypoints.min.js"></script>
@@ -14,7 +14,7 @@
 <script src="{{ .Site.BaseURL }}js/owl.carousel.min.js"></script>
 
 <!-- gmaps -->  
-<script src="https://maps.googleapis.com/maps/api/js?v=3.exp&amp;sensor=false" data-turbolinks-eval="false"></script>
+<script src="//maps.googleapis.com/maps/api/js?v=3.exp&amp;sensor=false" data-turbolinks-eval="false"></script>
 <script src="{{ .Site.BaseURL }}js/gmaps.js"></script>
 
 {{ if isset .Site.Params "contact" }}


### PR DESCRIPTION
If theme is deployed on a SSL server, the http url's are blocked, and therefore stop the page rendering. The amended https url's have been checked and work fine, on both http & https servers.

Paul