### PR TITLE
Correct theme name in example site

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To take full advantage of the features in this theme you can add variables to yo
 ```toml
 baseurl = "http://www.yourdomain.com/"
 languageCode = "en-us"
-theme = "universal"
+theme = "hugo-universal-theme"
 title = "Universal"
 # Enable comments by entering your Disqus shortname
 disqusShortname = "devcows"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,7 +8,7 @@ googleAnalytics = ""
 
 # Define the number of posts per page
 paginate = 10
-theme = "universal"
+theme = "hugo-universal-theme"
 
 [params]
     author = "DevCows"


### PR DESCRIPTION
The config file tries to find 'universal' instead of 'hugo-universal-theme'.