### PR TITLE
hide overflow for recent blog image

### DIFF
--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -21,7 +21,7 @@
                 <div class="col-md-3 col-sm-6">
                     <div class="box-image-text blog">
                         <div class="top">
-                            <div class="image">
+                            <div class="image" style="overflow:hidden">
                                 {{ if isset .Params "banner" }}
                                 <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="" >
                                 {{ else }}


### PR DESCRIPTION
Recent blog images are too big, hiding the titles etc. 

![screenshot 2016-09-06 11 27 35](https://cloud.githubusercontent.com/assets/527296/18258181/1eaa9228-7425-11e6-8634-278eba3ccfd7.png)

The new code will now box up the image

![screenshot 2016-09-06 11 27 51](https://cloud.githubusercontent.com/assets/527296/18258183/1f2b576e-7425-11e6-95e8-b052be0720f5.png)
