### PR TITLE
Sort features and carousel by data "weight"

### DIFF
--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -6,7 +6,7 @@
         <div class="dark-mask"></div>
         <div class="container">
             <div class="homepage owl-carousel">
-                {{ range .Site.Data.carousel }}
+                {{ range sort .Site.Data.carousel "weight" }}
                 <div class="item">
                     <div class="row">
                         <div class="col-sm-5 right">

--- a/layouts/partials/features.html
+++ b/layouts/partials/features.html
@@ -5,7 +5,7 @@
     <div class="container">
         <div class="col-md-12">
             <div class="row">
-                {{ range .Site.Data.features }}
+                {{ range sort .Site.Data.features "weight" }}
                 <div class="col-md-4">
                     <div class="box-simple">
                         <div class="icon">


### PR DESCRIPTION
The "weight" parameter on carousel and features data was ignored, sort by it in the appropriate templates.