### PR TITLE
Always submit E-mail form to formspree over HTTPS

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -13,7 +13,7 @@
                     <h3>Contact form</h3>
                 </div>
 
-                <form method="post" action="//formspree.io/{{ .Site.Params.email }}">
+                <form method="post" action="https://formspree.io/{{ .Site.Params.email }}">
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">


### PR DESCRIPTION
* http produces an "empty form" error - could be a formspree bug
* personal information (name + E-mail) ought to be secure by default
* form submission _to_ HTTPS from insecure pages shouldn't produce any client-side issues