### PR TITLE
Contact form email in params for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Since this Hugo sites are static, the contact form uses [Formspree](https://form
 To enable the form in the contact page, just type your Formspree email in the `config.toml` file.
 
 ```yaml
+[params]
 email = "your@email.com"
 ```
 


### PR DESCRIPTION
After fumbling around for a bit, I realized that `email` had to be in `[params]`. This tiny content edit just helps make that clearer for Hugo noobies.