### PR TITLE
Fix displaying 'Recent Posts' on footer when recent_posts.param is no…

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,6 +13,7 @@
         <!-- /.col-md-4 -->
         {{ end }}
 
+        {{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }} 
         <div class="col-md-4 col-sm-6">
 
             <h4>Recent posts</h4>
@@ -40,6 +41,7 @@
 
         </div>
         <!-- /.col-md-4 -->
+        {{ end }} {{ end }}
 
         {{ if isset .Site.Params "address" }}
         <div class="col-md-4 col-sm-6">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,9 +13,9 @@
         <!-- /.col-md-4 -->
         {{ end }}
 
-        {{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }} 
         <div class="col-md-4 col-sm-6">
 
+            {{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }} 
             <h4>Recent posts</h4>
 
             <div class="blog-entries">
@@ -38,10 +38,10 @@
             </div>
 
             <hr class="hidden-md hidden-lg">
+            {{ end }} {{ end }}
 
         </div>
         <!-- /.col-md-4 -->
-        {{ end }} {{ end }}
 
         {{ if isset .Site.Params "address" }}
         <div class="col-md-4 col-sm-6">


### PR DESCRIPTION
Fixed bug that displays 'Recent Posts' on footer when params,recent_posts disabled