### PR TITLE
Allow 3 sets of features per row.

### DIFF
--- a/layouts/partials/features.html
+++ b/layouts/partials/features.html
@@ -17,7 +17,7 @@
                         <p>{{ $element.description }}</p>
                     </div>
                 </div>
-		{{ if eq (mod $index 3) 2 }}
+		{{ if or (eq (mod $index 3) 2) (eq $index (sub (len $.Site.Data.features) 1 )) }}
 			</div>
 		</div>
 		{{ end }}		

--- a/layouts/partials/features.html
+++ b/layouts/partials/features.html
@@ -3,21 +3,25 @@
 {{ if gt (len .Site.Data.features) 0 }}
 <section class="bar background-white">
     <div class="container">
-        <div class="col-md-12">
+        {{ range $index, $element := sort .Site.Data.features "weight" }}
+		{{ if eq (mod $index 3) 0 }}
+		<div class="col-md-12">
             <div class="row">
-                {{ range sort .Site.Data.features "weight" }}
-                <div class="col-md-4">
+		{{ end }}
+				<div class="col-md-4">
                     <div class="box-simple">
                         <div class="icon">
                             <i class="{{ .icon }}"></i>
                         </div>
-                        <h3>{{ .name }}</h3>
-                        <p>{{ .description }}</p>
+                        <h3>{{ $element.name }}</h3>
+                        <p>{{ $element.description }}</p>
                     </div>
                 </div>
-                {{ end }}
-            </div>
-        </div>
+		{{ if eq (mod $index 3) 2 }}
+			</div>
+		</div>
+		{{ end }}		
+        {{ end }}
     </div>
 </section>
 {{ end }}


### PR DESCRIPTION
The current template puts all the features into a single bootstrap row.

![image](https://cloud.githubusercontent.com/assets/13352856/23693558/cf28fbe0-0439-11e7-81a0-68634ea4f375.png)

This should have a separate row per 3 items which is what this PR addresses.
Also address when there is not an un-even number of rows.