### PR TITLE
Correctly apply maps API Key

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,7 +6,7 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.1/jquery.waypoints.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/Counter-Up/1.0/jquery.counterup.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-parallax/1.1.3/jquery-parallax.js"></script>
-{{ if not ( eq .Site.Params.googleMapsApiKey "" ) }}
+{{ if .Site.Params.googleMapsApiKey }}
 <script src="//maps.googleapis.com/maps/api/js?key={{.Site.Params.googleMapsApiKey}}&v=3.exp"></script>
 {{ else }}
 <script src="//maps.googleapis.com/maps/api/js?v=3.exp"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,7 +6,7 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.1/jquery.waypoints.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/Counter-Up/1.0/jquery.counterup.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-parallax/1.1.3/jquery-parallax.js"></script>
-{{ if isset .Site.Params "googleMapsApiKey" }}
+{{ if not ( eq .Site.Params.googleMapsApiKey "" ) }}
 <script src="//maps.googleapis.com/maps/api/js?key={{.Site.Params.googleMapsApiKey}}&v=3.exp"></script>
 {{ else }}
 <script src="//maps.googleapis.com/maps/api/js?v=3.exp"></script>


### PR DESCRIPTION
Use equality to empty string rather than isset when using the api key.

Reference : https://discuss.gohugo.io/t/solved-how-to-check-if-a-parameter-exists-in-config-toml-not-under-params/5569