### PR TITLE
Enable markdown formatting on landing page descriptions (fixes #59)

### DIFF
--- a/layouts/partials/features.html
+++ b/layouts/partials/features.html
@@ -14,13 +14,13 @@
                             <i class="{{ .icon }}"></i>
                         </div>
                         <h3>{{ $element.name }}</h3>
-                        <p>{{ $element.description }}</p>
+                        <p>{{ $element.description | markdownify }}</p>
                     </div>
                 </div>
 		{{ if or (eq (mod $index 3) 2) (eq $index (sub (len $.Site.Data.features) 1 )) }}
 			</div>
 		</div>
-		{{ end }}		
+		{{ end }}
         {{ end }}
     </div>
 </section>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
         <div class="col-md-4 col-sm-6">
             <h4>{{ i18n "aboutUs" }}</h4>
 
-            {{ .Site.Params.about_us | safeHTML }}
+            {{ .Site.Params.about_us | markdownify }}
 
             <hr class="hidden-md hidden-lg hidden-sm">
 
@@ -15,7 +15,7 @@
 
         <div class="col-md-4 col-sm-6">
 
-            {{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }} 
+            {{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }}
             <h4>{{ i18n "recentPosts" }}</h4>
 
             <div class="blog-entries">
@@ -48,7 +48,7 @@
 
           <h4>{{ i18n "contactTitle" }}</h4>
 
-            {{ .Site.Params.address | safeHTML }}
+            {{ .Site.Params.address | markdownify }}
 
             <a href="/contact" class="btn btn-small btn-template-main">{{ i18n "contactGoTo" }}</a>
 

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -9,7 +9,7 @@
             </div>
 
             <p class="lead">
-              {{ .Site.Params.recent_posts.subtitle }}
+              {{ .Site.Params.recent_posts.subtitle | markdownify }}
             </p>
 
             <!-- *** BLOG HOMEPAGE *** -->

--- a/layouts/partials/testimonials.html
+++ b/layouts/partials/testimonials.html
@@ -10,7 +10,7 @@
                 </div>
 
                 <p class="lead">
-                  {{ .Site.Params.testimonials.subtitle }}
+                  {{ .Site.Params.testimonials.subtitle | markdownify }}
                 </p>
 
                 <!-- *** TESTIMONIALS CAROUSEL *** -->
@@ -20,7 +20,7 @@
                     <li class="item">
                         <div class="testimonial same-height-always">
                             <div class="text">
-                                <p>{{ .text }}</p>
+                                <p>{{ .text | markdownify }}</p>
                             </div>
                             <div class="bottom">
                                 <div class="icon"><i class="fa fa-quote-left"></i>


### PR DESCRIPTION
Enables markdown on the following landing page texts:

- Feature descriptions
- About us (footer)
- Contact address (footer)
- Recent posts subtitle
- Testimonials subtitle and texts