### PR TITLE
Add top bar with social links from official theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This Hugo theme was ported from [Bootstrapious](http://bootstrapious.com/p/unive
   * [Menu](#menu)
   * [Sidebar widgets](#sidebar-widgets)
   * [Blog post thumbnails](#blog-post-thumbnails)
+  * [Top bar](#top-bar)
   * [Landing page](#landing-page)
     * [Carousel](#carousel)
     * [Features](#features)
@@ -172,6 +173,34 @@ You can enable/disable them under `params.widgets`.
     search = true
     categories = true
     tags = true
+```
+
+### Top bar
+
+The top bar is typically used to provide contact information and social links. It is disabled by default, and it can be enabled inside the `params.topbar` settings.
+
+```toml
+[params.topbar]
+    enable = true
+    text = "<p>Contact us on +420 777 555 333 or hello@universal.com.</p>"
+```
+
+The `text` shows up on the left side and accepts HTML.
+
+The social links on the right side are configured as a top-level menu.
+
+```toml
+[[menu.topbar]]
+    weight = 1
+    name = "GitHub"
+    url = "https://github.com/devcows/hugo-universal-theme"
+    pre = "<i class='fa fa-2x fa-github'></i>"
+
+[[menu.topbar]]
+    weight = 2
+    name = "Facebook"
+    url = "http://facebook.com"
+    pre = "<i class='fa fa-2x fa-facebook'></i>"
 ```
 
 ### Blog post thumbnails

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,6 +14,8 @@ paginate = 10
 
 [menu]
 
+# Main menu
+
 [[menu.main]]
     name = "Home"
     url  = "/"
@@ -34,6 +36,32 @@ paginate = 10
     name = "Contact"
     url  = "/contact/"
     weight = 4
+
+# Top bar social links menu
+
+[[menu.topbar]]
+    weight = 1
+    name = "GitHub"
+    url = "https://github.com/devcows/hugo-universal-theme"
+    pre = "<i class='fa fa-2x fa-github'></i>"
+
+[[menu.topbar]]
+    weight = 2
+    name = "Facebook"
+    url = "http://facebook.com"
+    pre = "<i class='fa fa-2x fa-facebook'></i>"
+
+[[menu.topbar]]
+    weight = 3
+    name = "Twitter"
+    url = "http://twitter.com"
+    pre = "<i class='fa fa-2x fa-twitter'></i>"
+
+[[menu.topbar]]
+    weight = 4
+    name = "Email"
+    url = "mailto:your@email.com"
+    pre = "<i class='fa fa-2x fa-envelope'></i>"
 
 [params]
     viewMorePostLink = "/blog/"
@@ -83,6 +111,15 @@ paginate = 10
 
 [Permalinks]
     blog = "/blog/:year/:month/:day/:filename/"
+
+# Enable or disable top bar with social icons
+[params.topbar]
+    enable = true
+    text = """<p class="hidden-sm hidden-xs">Contact us on +420 777 555 333 or hello@universal.com.</p>
+      <p class="hidden-md hidden-lg"><a href="#" data-animate-hover="pulse"><i class="fa fa-phone"></i></a>
+      <a href="#" data-animate-hover="pulse"><i class="fa fa-envelope"></i></a>
+      </p>
+      """
 
 # Enable and disable widgets for the right sidebar
 [params.widgets]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,8 @@
 
         <header>
 
+          {{ partial "top.html" . }}
+
           {{ partial "nav.html" . }}
 
         </header>

--- a/layouts/partials/top.html
+++ b/layouts/partials/top.html
@@ -1,0 +1,18 @@
+{{ if .Site.Params.topbar.enable }}
+<div id="top">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-5">
+        {{ .Site.Params.topbar.text | safeHTML }}
+      </div>
+      <div class="col-xs-7">
+        <div class="social">
+          {{ range .Site.Menus.topbar.ByWeight }}
+          <a href="{{ .URL }}" target="_blank" style="opacity: 1;">{{ .Pre }}</a>
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
This adds the official top bar typically used to include contact information
and social links.

- Ability to enable/disable the top bar (disabled by default)
- Ability to customize the text message
- Ability to customize the social links and icons from config.toml
- Compatible with older config.toml
- Fixes #73