### PR TITLE
Add Google Maps API Key for Hugo showcase site

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,7 +42,7 @@ paginate = 10
     defaultDescription = "Site template made by devcows using hugo"
 
     # Google Maps API key (if not set will default to not passing a key.)
-    googleMapsApiKey = ""
+    googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
 
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "default"

--- a/layouts/partials/map.html
+++ b/layouts/partials/map.html
@@ -3,6 +3,7 @@
       <div class="hidden">
         <input id="gmap-lat" value="{{ .Site.Params.latitude }}" />
         <input id="gmap-lng" value="{{ .Site.Params.longitude }}" />
+        <input id="gmap-marker" value="{{ .Site.BaseURL }}img/marker.png" />
         {{ if isset .Site.Params "direction" }}
           <input id="gmap-dir" value="{{ .Site.Params.direction }}" />
         {{ else }}

--- a/static/js/gmaps.init.js
+++ b/static/js/gmaps.init.js
@@ -9,7 +9,7 @@ function map () {
     var lat = $('#gmap-lat').val()
     var lng = $('#gmap-lng').val()
     var direction = $('#gmap-dir').val()
-    var image = '/img/marker.png'
+    var image = $('#gmap-marker').val()
 
     var styles =
       [


### PR DESCRIPTION
Adding Google Maps API key with restrictive usage. It can only be used
by the demo site on the Hugo Themes showcase. This fixes the error
in the contact page when displaying the map.

![image](https://cloud.githubusercontent.com/assets/3786750/26492281/8ffa70d0-4213-11e7-9eba-8ba61cd6b316.png)

Related issue: #68

URL: https://themes.gohugo.io/theme/hugo-universal-theme/

Also, this fixes the marker image path in contact page map.