### PR TITLE
Marked IE specific libs as safeHTML so it's not stripped by Hugo

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,10 +41,12 @@
   <link href="{{ .Site.BaseURL }}css/custom.css" rel="stylesheet">
 
   <!-- Responsivity for older IE -->
+  {{ `
     <!--[if lt IE 9]>
         <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
         <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+  ` | safeHTML }}
 
   <!-- Favicon and apple touch icons-->
   <link rel="shortcut icon" href="{{ .Site.BaseURL }}img/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
By default Hugo strips out comments, as a by effect it also strips out IE specific libs like html5shiv. To prevent those libs from being stripped the HTML is now marked as safe.

https://gohugo.io/templates/go-templates/#internet-explorer-conditional-comments-using-pipes