### PR TITLE
Set class to menu item when active

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -26,17 +26,6 @@ paginate = 10
     url  = "/blog/"
     weight = 2
 
-[[menu.main]]
-    name = "FAQ"
-    identifier = "faq"
-    url  = "/faq/"
-    weight = 3
-
-[[menu.main]]
-    name = "Contact"
-    url  = "/contact/"
-    weight = 4
-
 # Top bar social links menu
 
 [[menu.topbar]]

--- a/exampleSite/content/contact.md
+++ b/exampleSite/content/contact.md
@@ -1,6 +1,9 @@
 +++
 title = "Contact"
 id = "contact"
+[menu.main]
+    identifier = "contact"
+    weight = 4
 +++
 
 # We are here to help you

--- a/exampleSite/content/faq.md
+++ b/exampleSite/content/faq.md
@@ -2,6 +2,9 @@
 title = "FAQ"
 description = "Frequently asked questions"
 keywords = ["FAQ","How do I","questions","what if"]
+[menu.main]
+    identifier = "faq"
+    weight = 3
 +++
 
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -20,8 +20,9 @@
 
             <div class="navbar-collapse collapse" id="navigation">
                 <ul class="nav navbar-nav navbar-right">
+                  {{ $currentNode := . }}
                   {{ range .Site.Menus.main }}
-                  <li class="dropdown">
+                  <li class="dropdown {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
                     {{ if .HasChildren }}
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
                     <ul class="dropdown-menu">


### PR DESCRIPTION
- Fixes #81
- Menu items for "contact" and "faq" have been moved to the respective contect (Markdown) files. It wasn't working otherwise, not sure why.
- Top level pages work fine, but individual blog posts do not highlight the "Blog" menu item. Need to investigate.