### PR TITLE
Improve i18n support

### DIFF
--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -66,3 +66,6 @@
 
 - id: older
   translation: "Més antic"
+
+- id: publishedOn
+  translation: "el"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -67,3 +67,5 @@
 - id: older
   translation: "Älter"
 
+- id: publishedOn
+  translation: "am"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -66,3 +66,6 @@
 
 - id: older
   translation: "Older"
+
+- id: publishedOn
+  translation: "on"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -66,3 +66,6 @@
 
 - id: older
   translation: "Más antiguo"
+
+- id: publishedOn
+  translation: "el"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -66,3 +66,6 @@
 
 - id: older
   translation: "Ancien"
+
+- id: publishedOn
+  translation: "sur"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -67,3 +67,5 @@
 - id: older
   translation: "Предыдущая запись"
 
+- id: publishedOn
+  translation: "на"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ .Site.LanguageCode }}">
 
   {{ partial "head.html" . }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ .Site.LanguageCode }}">
 
   {{ partial "head.html" . }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -42,7 +42,7 @@
                                     <div class="clearfix">
                                         <p class="author-category">
                                           {{ if isset .Params "author" }}
-                                          By <a href="#">{{ .Params.author }}</a>
+                                          {{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a>
                                           {{ end }}
                                           {{ if isset .Params "categories" }}
                                           {{ if gt (len .Params.categories) 0 }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ .Site.LanguageCode }}">
 
   {{ partial "head.html" . }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
 
                     <div class="col-md-9" id="blog-post">
 
-                        <p class="text-muted text-uppercase mb-small text-right">{{ if .Params.author }}By <a href="#">{{ .Params.author }}</a> | {{ end }}{{ .Date.Format .Site.Params.date_format }}</p>
+                        <p class="text-muted text-uppercase mb-small text-right">{{ if .Params.author }}{{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a> | {{ end }}{{ .Date.Format .Site.Params.date_format }}</p>
 
                         <div id="post-content">
                           {{ .Content }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ .Site.LanguageCode }}">
 
   {{ partial "head.html" . }}
 

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ .Site.LanguageCode }}">
 
   {{ partial "head.html" . }}
 

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -40,9 +40,9 @@
                             <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
                             <p class="author-category">
                             {{ with .Params.author }}
-                            By <a href="#">{{ . }}</a>
+                            {{ i18n "authorBy" }} <a href="#">{{ . }}</a>
                             {{ end }}
-                            on {{ .Date.Format .Site.Params.date_format }}
+                            {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
                             </p>
                             <p class="intro">{{ .Summary }}</p>
                             <p class="read-more">


### PR DESCRIPTION
I found out that the article meta information prepositions (`By` and `On`) were not internationalized. So I added them to the layout files and the i18n translations. I am not quite sure about the russian and french translation.

I also fixed the language code, which now uses `.Site.LanguageCode`.

Thanks!