### PR TITLE
Using the `themesDir` option instead of a softlink.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ install:
 script:
   - npm run lint
   - cd exampleSite
-  - mkdir themes
-  - ln -s ../../ themes/hugo-universal-theme
   - hugo
 notifications:
   slack:

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,7 @@
 baseurl = "https://example.org"
 title = "Universal"
 theme = "hugo-universal-theme"
+themesDir = "../.."
 languageCode = "en-us"
 # Site language. Available translations in the theme's `/i18n` directory.
 defaultContentLanguage = "en"


### PR DESCRIPTION
Using the `themesDir` option instead of a softlink. It solves two things:
* the softlink doesn't work on Windows.
* after checkout, new contributors can immediately do `cd exampleSite` and run `hugo serve`

First PR under the #101 umbrella.