### PR TITLE
Switch from using Site.BaseURL to relative URLs.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,6 +8,8 @@ defaultContentLanguage = "en"
 disqusShortname = "devcows"
 # Enable Google Analytics by entering your tracking code
 googleAnalytics = ""
+# Enable URLs to be regenerated relative to sit root
+RelativeURLs = true
 
 # Define the number of posts per page
 paginate = 10

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -21,7 +21,7 @@
                     <div class="box">
 
                         <p class="text-center">
-                            <a href="{{ .Site.BaseURL }}">
+                            <a href="/">
                                 <img src="{{ .Site.Params.logo }}" alt="{{ .Title }} logo">
                             </a>
                         </p>
@@ -29,7 +29,7 @@
                         <h3>We are sorry - this page is not here anymore</h3>
                         <h4 class="text-muted">Error 404 - Page not found</h4>
 
-                        <p class="buttons"><a href="{{ .Site.BaseURL }}" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
+                        <p class="buttons"><a href="/" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
                         </p>
                     </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -30,9 +30,9 @@
                                   <div class="image">
                                       <a href="{{ .Permalink }}">
                                           {{ if .Params.banner }}
-                                          <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="">
+                                          <img src="/{{ .Params.banner }}" class="img-responsive" alt="">
                                           {{ else }}
-                                          <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                                          <img src="/img/placeholder.png" class="img-responsive" alt="">
                                           {{ end }}
                                       </a>
                                   </div>
@@ -46,7 +46,7 @@
                                           {{ end }}
                                           {{ if isset .Params "categories" }}
                                           {{ if gt (len .Params.categories) 0 }}
-                                          in <a href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
+                                          in <a href="/categories/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
                                           {{ end }}
                                           {{ end }}
 
@@ -65,13 +65,13 @@
 
                         <ul class="pager">
                             {{ if .Paginator.HasPrev }}
-                            <li class="previous"><a href="{{ .Site.BaseURL }}{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
+                            <li class="previous"><a href="/{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
                             {{ else }}
                             <li class="previous disabled"><a href="#">&larr; {{ i18n "newer" }}</a></li>
                             {{ end }}
 
                             {{ if .Paginator.HasNext }}
-                            <li class="next"><a href="{{ .Site.BaseURL }}{{ .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
+                            <li class="next"><a href="/{{ .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
                             {{ else }}
                             <li class="next disabled"><a href="#">{{ i18n "older" }} &rarr;</a></li>
                             {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,9 +24,9 @@
                     <div class="image same-height-always">
                         <a href="{{ .Permalink }}">
                           {{ if isset .Params "banner" }}
-                            <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="">
+                            <img src="/{{ .Params.banner }}" class="img-responsive" alt="">
                           {{ else }}
-                            <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                            <img src="/img/placeholder.png" class="img-responsive" alt="">
                           {{ end }}
                         </a>
                     </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,18 +27,18 @@
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
   <!-- Css animations  -->
-  <link href="{{ .Site.BaseURL }}css/animate.css" rel="stylesheet">
+  <link href="/css/animate.css" rel="stylesheet">
 
   <!-- Theme stylesheet, if possible do not edit this stylesheet -->
   {{ if and (isset .Site.Params "style") .Site.Params.style }}
-    <link href="{{ .Site.BaseURL }}css/style.{{ .Site.Params.style }}.css" rel="stylesheet" id="theme-stylesheet">
+    <link href="/css/style.{{ .Site.Params.style }}.css" rel="stylesheet" id="theme-stylesheet">
   {{ else }}
-    <link href="{{ .Site.BaseURL }}css/style.default.css" rel="stylesheet" id="theme-stylesheet">
+    <link href="/css/style.default.css" rel="stylesheet" id="theme-stylesheet">
   {{ end }}
 
 
   <!-- Custom stylesheet - for your changes -->
-  <link href="{{ .Site.BaseURL }}css/custom.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
 
   <!-- Responsivity for older IE -->
   {{ `
@@ -49,12 +49,12 @@
   ` | safeHTML }}
 
   <!-- Favicon and apple touch icons-->
-  <link rel="shortcut icon" href="{{ .Site.BaseURL }}img/favicon.ico" type="image/x-icon" />
-  <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}img/apple-touch-icon.png" />
+  <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" href="/img/apple-touch-icon.png" />
   <!-- owl carousel css -->
 
-  <link href="{{ .Site.BaseURL }}css/owl.carousel.css" rel="stylesheet">
-  <link href="{{ .Site.BaseURL }}css/owl.theme.css" rel="stylesheet">
+  <link href="/css/owl.carousel.css" rel="stylesheet">
+  <link href="/css/owl.theme.css" rel="stylesheet">
 
   <link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -4,9 +4,9 @@
 
         <div class="container">
             <div class="navbar-header">
-                <a class="navbar-brand home" href="{{ .Site.BaseURL }}">
-                    <img src="{{ .Site.BaseURL }}img/logo.png" alt="{{ .Title }} logo" class="hidden-xs hidden-sm">
-                    <img src="{{ .Site.BaseURL }}img/logo-small.png" alt="{{ .Title }} logo" class="visible-xs visible-sm">
+                <a class="navbar-brand home" href="/">
+                    <img src="/img/logo.png" alt="{{ .Title }} logo" class="hidden-xs hidden-sm">
+                    <img src="/img/logo-small.png" alt="{{ .Title }} logo" class="visible-xs visible-sm">
                     <span class="sr-only">{{ .Title }} - {{ i18n "navHome" }}</span>
                 </a>
                 <div class="navbar-buttons">

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -23,9 +23,9 @@
                         <div class="top">
                             <div class="image" style="overflow:hidden">
                                 {{ if isset .Params "banner" }}
-                                <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="" >
+                                <img src="/{{ .Params.banner }}" class="img-responsive" alt="" >
                                 {{ else }}
-                                <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                                <img src="/img/placeholder.png" class="img-responsive" alt="">
                                 {{ end }}
                             </div>
                             <div class="bg"></div>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -11,9 +11,9 @@
 {{ else }}
 <script src="//maps.googleapis.com/maps/api/js?v=3.exp"></script>
 {{ end }}
-<script src="{{ .Site.BaseURL }}js/hpneo.gmaps.js"></script>
-<script src="{{ .Site.BaseURL }}js/gmaps.init.js"></script>
-<script src="{{ .Site.BaseURL }}js/front.js"></script>
+<script src="/js/hpneo.gmaps.js"></script>
+<script src="/js/gmaps.init.js"></script>
+<script src="/js/front.js"></script>
 
 <!-- owl carousel -->
-<script src="{{ .Site.BaseURL }}js/owl.carousel.min.js"></script>
+<script src="/js/owl.carousel.min.js"></script>

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -10,7 +10,7 @@
     <div class="panel-body">
         <ul class="nav nav-pills nav-stacked">
             {{ range $name, $items := .Site.Taxonomies.categories }}
-            <li><a href="{{ $.Site.BaseURL }}categories/{{ $name | urlize | lower }}">{{ $name }} ({{ len $items }})</a>
+            <li><a href="/categories/{{ $name | urlize | lower }}">{{ $name }} ({{ len $items }})</a>
             </li>
             {{ end }}
         </ul>

--- a/layouts/partials/widgets/tags.html
+++ b/layouts/partials/widgets/tags.html
@@ -9,7 +9,7 @@
     <div class="panel-body">
         <ul class="tag-cloud">
             {{ range $name, $items := .Site.Taxonomies.tags }}
-            <li><a href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower }}"><i class="fa fa-tags"></i> {{ $name }}</a>
+            <li><a href="/tags/{{ $name | urlize | lower }}"><i class="fa fa-tags"></i> {{ $name }}</a>
             </li>
             {{ end }}
         </ul>


### PR DESCRIPTION
When deploying a site, the site's `BaseURL` may not necessarily be known a-priori.  One real world example is when staging a site on Google app engine (the site's name is concatenated with a long random alphanumeric string).

This issue is also mentioned in the Hugo project, and a fix was merged in 2015:
gohugoio/hugo#1104

Employing this fix requires themes & layouts to use the `/foo.html` notation instead of `{{ .Site.BaseURL}}/link.html`

This PR does the following:
* Updates `exampleSite` to enable relative URLs
* Updates this theme's layouts to switch to using the `/foo.html` notation.

Once this is merged, users of the theme will have to add `RelativeURLs = true` to their `config.toml`.