### PR TITLE
README.md: fix link to Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Hugo theme was ported from [Bootstrapious](http://bootstrapious.com/p/unive
 
 ## Table of Contents
 
-* [Theme features](#theme-features)
+* [Features](#features)
 * [Installation](#installation)
 * [Configuration](#configuration)
   * [Style](#style)


### PR DESCRIPTION
"Theme features" link in Table of Contents wasn't working because the created anchor name is determined by the heading -- which is "Features". Therefore, `[Features](#features)` must be used.