### PR TITLE
fix for images not displayed in list

### DIFF
--- a/static/js/front.js
+++ b/static/js/front.js
@@ -221,7 +221,9 @@ function counters () {
 function pictureZoom () {
   $('.product .image, .post .image, .photostream div').each(function () {
     var imgHeight = $(this).find('img').height()
-    $(this).height(imgHeight)
+    if (imgHeight) {
+      $(this).height(imgHeight)
+    }
   })
 }
 


### PR DESCRIPTION
issue is described in
https://github.com/devcows/hugo-universal-theme/issues/142

Reason: image height is set, when image has not been loaded yet.

Don't set height if image height is unknown.