### PR TITLE
make navbar use site param for site logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ googleAnalytics = "UA-XXXXX-X"
 
 Leave the `googleAnalytics` key empty to disable it.
 
+### Logo
+
+You can select the logos using the logo and logo_small parameters. The logo_small value will be used when the site is rendered on small screens.
 
 ### Contact form
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -98,6 +98,7 @@ paginate = 10
     date_format = "January 2, 2006"
 
     logo = "img/logo.png"
+    logo_small = "img/logo-small.png"
     address = """<p><strong>Universal Ltd.</strong>
         <br>13/25 New Avenue
         <br>Newtown upon River

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -5,8 +5,8 @@
         <div class="container">
             <div class="navbar-header">
                 <a class="navbar-brand home" href="{{ .Site.BaseURL }}">
-                    <img src="{{ .Site.BaseURL }}img/logo.png" alt="{{ .Title }} logo" class="hidden-xs hidden-sm">
-                    <img src="{{ .Site.BaseURL }}img/logo-small.png" alt="{{ .Title }} logo" class="visible-xs visible-sm">
+                    <img src="{{ .Site.BaseURL }}{{ .Site.Params.logo }}" alt="{{ .Title }} logo" class="hidden-xs hidden-sm">
+                    <img src="{{ .Site.BaseURL }}{{ .Site.Params.logo_small }}" alt="{{ .Title }} logo" class="visible-xs visible-sm">
                     <span class="sr-only">{{ .Title }} - {{ i18n "navHome" }}</span>
                 </a>
                 <div class="navbar-buttons">


### PR DESCRIPTION
This PR address the concerns raised in #126. Namely, it make the navbar use the logo site config parameter so that the a custom image file can be used.

The example site config and readme were also updated to document the feature.