### PR TITLE
fix minor issue in id "newer" for pt-br (gender of nouns)

### DIFF
--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -62,7 +62,7 @@
   translation: "Sobre nós"
 
 - id: newer
-  translation: "Mais novas"
+  translation: "Mais novos"
 
 - id: older
   translation: "Mais antigos"


### PR DESCRIPTION
In Portuguese, "posts" noun is a masculine gender, so we need to use "Mais novos" instead of "Mais novas".