### PR TITLE
Active class on top level items and blog post parent menu item

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -20,8 +20,10 @@
 
             <div class="navbar-collapse collapse" id="navigation">
                 <ul class="nav navbar-nav navbar-right">
+                  {{ $current := . }}
                   {{ range .Site.Menus.main }}
-                  <li class="dropdown">
+                  {{ $topLevel := replace .URL "/" "" }}
+                  <li class="dropdown{{ if not $current.IsHome }}{{ if or (eq $current.URL .URL) (eq $current.Type $topLevel) }} active{{ end }}{{ end }}">
                     {{ if .HasChildren }}
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
                     <ul class="dropdown-menu">


### PR DESCRIPTION
Not much activity on #81, thought this might help.  An active class is applied to top-level menu items as well as the `Blog` menu item on blog posts.