### PR TITLE
Fix formspree. Add possibility to send request through plain HTTP POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ You can optionally add the google maps widget defining latitude and longitude in
 
 Since this Hugo sites are static, the contact form uses [Formspree](https://formspree.io/) as a proxy. The form makes a POST request to their servers to send the actual email. Visitors can send up to a 1000 emails each month for free.
 
-To enable the form in the contact page, just type your Formspree email in the `config.toml` file.
+To enable the form in the contact page, just type your Formspree email in the `config.toml` file, and specify whether to use ajax(paid) to send request or plain HTTP POST(free).
 
 ```yaml
 [params]
 email = "your@email.com"
+contact_form_ajax = false
 ```
 
 ### Menu

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -90,6 +90,7 @@ paginate = 10
     #
     # Enable the contact form by entering your Formspree.io email
     email = "your@email.com"
+    contact_form_ajax = false
 
     about_us = "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>"
     copyright = "Copyright (c) 2015 - 2016, YourCompany; all rights reserved."

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -15,11 +15,7 @@
 
                 <div id="contact-message"></div>
 
-                {{ if .Site.Params.contact_form_ajax }}
-                <form class="contact-form-ajax" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
-                {{ else }}
-                <form class="contact-form-post" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
-                {{ end }}
+                <form class="contact-form-{{ with .Site.Params.contact_form_ajax }}ajax{{ else }}post{{ end }}" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -15,7 +15,7 @@
 
                 <div id="contact-message"></div>
 
-                <form class="contact-form-{{ with .Site.Params.contact_form_ajax }}ajax{{ else }}post{{ end }}" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
+                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="https://formspree.io/{{ .Site.Params.email }}">
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -15,7 +15,11 @@
 
                 <div id="contact-message"></div>
 
-                <form class="contact-form" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
+                {{ if .Site.Params.contact_form_ajax }}
+                <form class="contact-form-ajax" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
+                {{ else }}
+                <form class="contact-form-post" method="post" action="https://formspree.io/{{ .Site.Params.email }}">
+                {{ end }}
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">

--- a/static/js/front.js
+++ b/static/js/front.js
@@ -25,6 +25,7 @@ $(function () {
 // Ajax contact
 function contactFormAjax () {
   var form = $('.contact-form-ajax')
+  if (typeof form === 'undefined') return false
   form.submit(function () {
     $this = $(this)
     $.post($(this).attr('action'),

--- a/static/js/front.js
+++ b/static/js/front.js
@@ -19,12 +19,13 @@ $(function () {
   animations()
   counters()
   demo()
-  contactForm()
+  contactFormAjax()
+  contactFormPost()
 })
 
 // Ajax contact
-function contactForm () {
-  var form = $('.contact-form')
+function contactFormAjax () {
+  var form = $('.contact-form-ajax')
   form.submit(function () {
     $this = $(this)
     $.post($(this).attr('action'),
@@ -39,6 +40,10 @@ function contactForm () {
       , 'json')
     return false
   })
+}
+
+function contactFormPost(){
+    var form = $('.contact-form-post')
 }
 
 /* for demo purpose only - can be deleted */

--- a/static/js/front.js
+++ b/static/js/front.js
@@ -20,7 +20,6 @@ $(function () {
   counters()
   demo()
   contactFormAjax()
-  contactFormPost()
 })
 
 // Ajax contact
@@ -40,10 +39,6 @@ function contactFormAjax () {
       , 'json')
     return false
   })
-}
-
-function contactFormPost(){
-    var form = $('.contact-form-post')
 }
 
 /* for demo purpose only - can be deleted */


### PR DESCRIPTION
Please let me know if this is satisfactory.

It works for me. It is live here if you want to test.
https://www.lagobello.com/contact/