### PR TITLE
replace deprecated Page.Hugo variable with global hugo function

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
   <meta name="description" content="{{ .Site.Params.DefaultDescription }}">	
   {{ end }}
 
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
As of Hugo 0.55, the following warning message appears when trying to build a site using this template:

```
WARN 2019/04/09 22:29:38 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
```

This pull request just follows the recommendation to use the global hugo function instead. More info can be found in [this hugo discussion thread](https://discourse.gohugo.io/t/pages-hugo-is-deprecated-as-of-0-55-0/17991).