### PR TITLE
replace deprecated Page.URL with Page.Permalink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -69,7 +69,7 @@
   <!-- Facebook OpenGraph tags -->
   <meta property="og:title" content="{{ .Title }}" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ .URL }}/" />
+  <meta property="og:url" content="{{ .Permalink }}/" />
   <meta property="og:image" content="{{ .Site.Params.logo }}" />
 
 </head>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -23,7 +23,7 @@
                   {{ $current := . }}
                   {{ range .Site.Menus.main }}
                   {{ $topLevel := replace .URL "/" "" }}
-                  <li class="dropdown{{ if not $current.IsHome }}{{ if or (eq $current.URL .URL) (eq $current.Type $topLevel) }} active{{ end }}{{ end }}">
+                  <li class="dropdown{{ if not $current.IsHome }}{{ if or (eq $current.RelPermalink .URL) (eq $current.Type $topLevel) }} active{{ end }}{{ end }}">
                     {{ if .HasChildren }}
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
                     <ul class="dropdown-menu">


### PR DESCRIPTION
As of Hugo 0.55, the following warning message appears when trying to build a site using this template:

```
WARN 2019/04/09 22:38:48 Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.
```

More info on the topic can be found here: [Hugo Themes Dont’s](https://discourse.gohugo.io/t/hugo-themes-donts/17714)