### PR TITLE
Use .Site.RegularPages instead of .Site.Pages for recent posts in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,7 +19,7 @@
             <h4>{{ i18n "recentPosts" }}</h4>
 
             <div class="blog-entries">
-                {{ range first 3 (where .Site.Pages "Type" "blog") }}
+                {{ range first 3 (where .Site.RegularPages "Type" "blog") }}
                 <div class="item same-height-row clearfix">
                     <div class="image same-height-always">
                         <a href="{{ .Permalink }}">


### PR DESCRIPTION
I believe `.Site.RegularPages` is more suitable here, otherwise the `Blog` section shows up in recent posts in footer.