### PR TITLE
improve navigation highlighting:

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ You can also define the menu items that will appear in the top bar. Edit the `[[
     weight = 4
 ```
 
-The `weight` parameter will determine the order of the menu entries.
+The `weight` key will determine the order of the menu entries.
+
+**Important:** Do not change the `identifier` key of existing menu entries!
 
 
 ### Sidebar widgets

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,22 +18,25 @@ paginate = 10
 # Main menu
 
 [[menu.main]]
+    identifier="home"
     name = "Home"
     url  = "/"
     weight = 1
 
 [[menu.main]]
+    identifier="blog"
     name = "Blog"
     url  = "/blog/"
     weight = 2
 
 [[menu.main]]
-    name = "FAQ"
     identifier = "faq"
+    name = "FAQ"
     url  = "/faq/"
     weight = 3
 
 [[menu.main]]
+    identifier = "contact"
     name = "Contact"
     url  = "/contact/"
     weight = 4

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -23,7 +23,7 @@
                   {{ $current := . }}
                   {{ range .Site.Menus.main }}
                   {{ $topLevel := replace .URL "/" "" }}
-                  <li class="dropdown{{ if not $current.IsHome }}{{ if or (eq $current.URL .URL) (eq $current.Type $topLevel) }} active{{ end }}{{ end }}">
+                  <li class="dropdown{{ if eq $current.RelPermalink .URL | or (eq $current.Type $topLevel) | or (and (eq .Identifier "blog") (in (slice "taxonomy" "taxonomyTerm") $current.Kind)) }} active{{ end }}">
                     {{ if .HasChildren }}
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
                     <ul class="dropdown-menu">

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -23,7 +23,7 @@
                   {{ $current := . }}
                   {{ range .Site.Menus.main }}
                   {{ $topLevel := replace .URL "/" "" }}
-                  <li class="dropdown{{ if eq $current.RelPermalink .URL | or (eq $current.Type $topLevel) | or (and (eq .Identifier "blog") (in (slice "taxonomy" "taxonomyTerm") $current.Kind)) }} active{{ end }}">
+                  <li class="dropdown{{ if eq $current.RelPermalink .URL | or (eq $current.Type $topLevel) | or (and (eq (default (trim .URL "/") .Identifier) "blog") (in (slice "taxonomy" "taxonomyTerm") $current.Kind)) }} active{{ end }}">
                     {{ if .HasChildren }}
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
                     <ul class="dropdown-menu">


### PR DESCRIPTION
- highlight blog section when on taxonomy sites (`/tags/*` and `/categories/*`)
- highlight home, too (same as PR #208)

The blog section is identified by its `identifier` key, which has the advantage that users can change the `name` and `url` of the blog menu item.

There is one basic assumption behind the code: There is only _one_ blog section in the whole site. I think this assumption is normally satisfied. If someone really wanted to create a site with multiple different blog sections, he/she would have to make other additional changes to this theme – which requires advanced knowledge of Hugo's internals anyway. For someone capable doing this, it should be rather trivial to also adjust the navigation partial to work as desired.