### PR TITLE
Update deprecated template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
   <meta name="description" content="{{ .Site.Params.DefaultDescription }}">	
   {{ end }}
 
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
Recent changes in Hugo has made the .Hugo variable deprecated. This results in the following warning:

_Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function._

Apparently the solution is to simply write "hugo" instead. 