### PR TITLE
[footer] Show recent posts from all mainSections

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Then, you can enable the section in the configuration file.
 
 #### Recent posts
 
-The recent posts sections shows the four latest published blog posts, with their featured image and a summary.
+The recent posts sections shows the four latest published blog posts, with their featured image and a summary. It defaults to show recent posts from all [main sections](https://gohugo.io/functions/where/#mainsections). This is either the section with the most posts or can be set explicitly in the configuration file (see linked docs).
 
 You can enable it in the configuration file.
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -71,6 +71,7 @@ paginate = 10
     viewMorePostLink = "/blog/"
     author = "DevCows"
     defaultKeywords = ["devows", "hugo", "go"]
+    mainSections = ["blog"]
     defaultDescription = "Site template made by devcows using hugo"
 
     # Social media

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,7 +19,7 @@
             <h4>{{ i18n "recentPosts" }}</h4>
 
             <div class="blog-entries">
-                {{ range first 3 (where .Site.RegularPages "Type" "blog") }}
+                {{ range first 3 (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
                 <div class="item same-height-row clearfix">
                     <div class="image same-height-always">
                         <a href="{{ .Permalink }}">


### PR DESCRIPTION
Similar to the `recent_posts.html` partial the footer currently only shows posts from the hardcoded 'blog' type.
This commit changes this to all `mainSections` of the site.