### PR TITLE
meta tags: check for image file existence and improve keywords generation

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -55,6 +55,8 @@
   {{ $is_blog := and (eq .Type "blog") (eq .Kind "page") }}
   {{ $has_image :=  isset .Params "banner" }}
   {{ $image := cond $has_image .Params.banner .Site.Params.default_sharing_image }}
+  {{ $is_valid_image := fileExists $image }}
+  {{ if $is_valid_image }}
   {{ $image_ext := path.Ext $image }}
   <meta property="og:locale" content="{{ replace .Site.LanguageCode "-" "_" }}">
   <meta property="og:site_name" content="{{ .Site.Title }}">
@@ -70,6 +72,7 @@
     <meta property="og:image:width" content="{{ .Width }}">
     <meta property="og:image:height" content="{{ .Height }}">
   {{ end }}
+  {{ end }}
   {{ with .Lastmod }}<meta property="og:updated_time" content="{{ .Format "2006-01-02T15:04:05Z0700" }}">{{ end }}
   {{ if $is_blog }}
     {{ with .Param "facebook_site" }}<meta property="article:publisher" content="https://www.facebook.com/{{ . }}/">{{ end }}
@@ -83,10 +86,12 @@
   {{ end }}
 
   <!-- Twitter Card meta tags -->
-  <meta name="twitter:card" content="summary{{ if and $is_blog $has_image }}_large_image{{ end }}">
+  <meta name="twitter:card" content="summary{{ if (and $is_blog (and $has_image $is_valid_image)) }}_large_image{{ end }}">
   {{ with .Param "twitter_site" }}<meta name="twitter:site" content="@{{ . }}">{{ end }}
   <meta name="twitter:title" content="{{ $title_plain | truncate 70 }}">
+  {{ if $is_valid_image }}
   <meta name="twitter:image" content="{{ $image | absURL }}">
+  {{ end }}
   <meta name="twitter:description" content="{{ $description_plain | truncate 200 }}">
   {{ with .Param "twitter_author" }}<meta name="twitter:creator" content="@{{ . }}">{{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,12 @@
   {{ $title_plain := .Title | markdownify | plainify }}
   <title>{{ $title_plain }}</title>
   <meta name="author" content="{{ .Param "author" }}" />
-  <meta name="keywords" content="{{ with .Keywords }}{{ delimit . ", " }}{{ else }}{{ delimit .Site.Params.defaultKeywords ", " }}{{ end }}">
+  {{ $keywords := .Site.Params.defaultKeywords }}
+  {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . | uniq }}{{ end }}{{ end }}
+  {{ if isset .Params "keywords" }}{{ range .Params.keywords }}{{ $keywords = $keywords | append . | uniq }}{{ end }}{{ end }}
+  {{ if gt (len $keywords) 0 }}
+  <meta name="keywords" content="{{ delimit $keywords ", " }}">
+  {{ end }}
   {{ $description_plain := default .Site.Params.defaultDescription .Description | markdownify | plainify }}
   <meta name="description" content="{{ $description_plain }}">
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
   {{ $title_plain := .Title | markdownify | plainify }}
   <title>{{ $title_plain }}</title>
   <meta name="author" content="{{ .Param "author" }}" />
-  {{ $keywords := .Site.Params.defaultKeywords }}
+  {{ $keywords := .Site.Params.defaultKeywords | default "" }}
   {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
   {{ if isset .Params "keywords" }}{{ range .Params.keywords }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
   {{ if gt (len $keywords) 0 }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
   {{ $title_plain := .Title | markdownify | plainify }}
   <title>{{ $title_plain }}</title>
   <meta name="author" content="{{ .Param "author" }}" />
-  {{ $keywords := .Site.Params.defaultKeywords | default "" }}
+  {{ $keywords := .Site.Params.defaultKeywords | default (slice "" | first 0) }}
   {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
   {{ if isset .Params "keywords" }}{{ range .Params.keywords }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
   {{ if gt (len $keywords) 0 }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -59,8 +59,8 @@
   <!-- Facebook OpenGraph tags -->
   {{ $is_blog := and (eq .Type "blog") (eq .Kind "page") }}
   {{ $has_image :=  isset .Params "banner" }}
-  {{ $image := cond $has_image .Params.banner .Site.Params.default_sharing_image }}
-  {{ $is_valid_image := fileExists $image }}
+  {{ $image := cond $has_image .Params.banner (.Site.Params.default_sharing_image | default "img/sharing-default.png") }}
+  {{ $is_valid_image := print "static/" $image | fileExists }}
   {{ if $is_valid_image }}
   {{ $image_ext := path.Ext $image }}
   <meta property="og:locale" content="{{ replace .Site.LanguageCode "-" "_" }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,10 +7,10 @@
   <title>{{ $title_plain }}</title>
   <meta name="author" content="{{ .Param "author" }}" />
   {{ $keywords := .Site.Params.defaultKeywords }}
-  {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . | uniq }}{{ end }}{{ end }}
-  {{ if isset .Params "keywords" }}{{ range .Params.keywords }}{{ $keywords = $keywords | append . | uniq }}{{ end }}{{ end }}
+  {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
+  {{ if isset .Params "keywords" }}{{ range .Params.keywords }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
   {{ if gt (len $keywords) 0 }}
-  <meta name="keywords" content="{{ delimit $keywords ", " }}">
+  <meta name="keywords" content="{{ delimit (uniq $keywords) ", " }}">
   {{ end }}
   {{ $description_plain := default .Site.Params.defaultDescription .Description | markdownify | plainify }}
   <meta name="description" content="{{ $description_plain }}">


### PR DESCRIPTION
This replaces ~~part of~~ #237 and should fix what @thejaywhy was trying to fix here: https://github.com/devcows/hugo-universal-theme/pull/236

- It ensures that a banner image actually exists before adding any image-related meta tags.
- It only adds the keywords meta tag if at minimum 1 keyword is found. Additionally it also adds any tags specified in the content front matter as keywords (while removing any duplicates).