### PR TITLE
use relative home URL

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -23,7 +23,7 @@
                         <h3>{{ i18n "404Message" | markdownify }}</h3>
                         <h4 class="text-muted">{{ i18n "404Error" | markdownify }}</h4>
 
-                        <p class="buttons"><a href="{{ .Site.BaseURL }}" class="btn btn-template-main"><i class="fas fa-home"></i> {{ i18n "404NavHome" | markdownify }}</a>
+                        <p class="buttons"><a href="{{ "/" | relURL }}" class="btn btn-template-main"><i class="fas fa-home"></i> {{ i18n "404NavHome" | markdownify }}</a>
                         </p>
                     </div>
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -4,7 +4,7 @@
 
         <div class="container">
             <div class="navbar-header">
-                <a class="navbar-brand home" href="{{ .Site.BaseURL }}">
+                <a class="navbar-brand home" href="{{ "/" | relURL }}">
                     <img src="{{ .Site.Params.logo | relURL }}" alt="{{ .Title }} logo" class="hidden-xs hidden-sm">
                     <img src="{{ .Site.Params.logo_small | relURL }}" alt="{{ .Title }} logo" class="visible-xs visible-sm">
                     <span class="sr-only">{{ .Title }} - {{ i18n "navHome" }}</span>


### PR DESCRIPTION
This PR replaces `.Site.BaseURL` with `"/" | relURL`. Using relative URLs is generally more portable, cf. https://github.com/devcows/hugo-universal-theme/pull/243 and https://github.com/devcows/hugo-universal-theme/pull/244

After this PR there is only one occurence left of `.Site.BaseURL`, found in `layouts/partials/widgets/search.html`.