### PR TITLE
replace site variable by absURL function

### DIFF
--- a/layouts/partials/widgets/search.html
+++ b/layouts/partials/widgets/search.html
@@ -10,7 +10,7 @@
         <form action="//google.com/search" method="get" accept-charset="UTF-8" role="search">
             <div class="input-group">
                 <input type="search" name="q" class="form-control" placeholder="{{ i18n "searchTitle" }}">
-                <input type="hidden" name="sitesearch" value="{{ .Site.BaseURL }}">
+                <input type="hidden" name="sitesearch" value="{{ "/" | absURL }}">
                 <span class="input-group-btn">
                     <button type="submit" class="btn btn-template-main"><i class="fas fa-search"></i></button>
                 </span>


### PR DESCRIPTION
This PR squashes the last occurence of `.Site.BaseURL` by replacing it with `"/" | absURL` (in `layouts/partials/widgets/search.html`). This should make the theme more portable. See also #247 