### PR TITLE
add googlemap enable in config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,22 +128,22 @@ id = "contact"
 +++
 ```
 
-You can enable or disable google maps in the section `params` at `config.toml`. `enableGoogleMaps` must be setted `true` or `false`, If you want disable google maps, just set `enableGoogleMaps = false`, then the `googleMapsApiKey`, `latitude`, `longitude` and `direction` will be ignored by default.
+You can enable or disable the Google Maps widget on the contact page by setting `params.enableGoogleMaps` to `true` or `false` in `config.toml`. Make sure to also provide a valid `googleMapsApiKey` if you decide to enable the widget – otherwise it likely won't work. By clicking on the pin, Google Maps opens a route description with the coordinates `latitude` and `longitude`. Additionally, you can define the `direction` if you want to have another destination for the directions or the Google Maps entry of your company. If `enableGoogleMaps` is set to `false` on the other hand, the subsequent `googleMapsApiKey`, `latitude`, `longitude` and `direction` will be ignored.
 
-You can optionally add the google maps widget defining latitude and longitude in the section `params` at `config.toml`. On pin click opens Google Maps directions with the coordinates. Additionally you can define direction if you want to have a different target set for directions or the google maps entry of your company.:
+Example configuration:
 
 ```yaml
 [params]
     ...
     enableGoogleMaps = true
-    googleMapsApiKey = ""
+    googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
 
     latitude = "-12.043333"
     longitude = "-77.028333"
     direction = "Desamparados Station, Distrito de Lima 15001, Peru"
 ```
 
-Since this Hugo sites are static, the contact form uses [Formspree](https://formspree.io/) as a proxy. The form makes a POST request to their servers to send the actual email. Visitors can send up to a 1000 emails each month for free.
+Since Hugo sites are static, the contact form uses [Formspree](https://formspree.io/) as a proxy. The form makes a POST request to their servers to send the actual email. Visitors can send up to a 1000 emails each month for free.
 
 To enable the form in the contact page, just type your Formspree email in the `config.toml` file, and specify whether to use ajax(paid) to send request or plain HTTP POST(free).
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,16 @@ id = "contact"
 +++
 ```
 
-You can optionally add the google maps widget defining latitude and longitude in the section `params` at `config.toml`. On pin click  opens Google Maps directions with the coordinates. Additionally you can define direction if you want to have a different target set for directions or the google maps entry of your company.:
+You can enable or disable google maps in the section `params` at `config.toml`. `enableGoogleMaps` must be setted `true` or `false`, If you want disable google maps, just set `enableGoogleMaps = false`, then the `googleMapsApiKey`, `latitude`, `longitude` and `direction` will be ignored by default.
+
+You can optionally add the google maps widget defining latitude and longitude in the section `params` at `config.toml`. On pin click opens Google Maps directions with the coordinates. Additionally you can define direction if you want to have a different target set for directions or the google maps entry of your company.:
 
 ```yaml
 [params]
     ...
+    enableGoogleMaps = true
+    googleMapsApiKey = ""
+
     latitude = "-12.043333"
     longitude = "-77.028333"
     direction = "Desamparados Station, Distrito de Lima 15001, Peru"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -80,6 +80,7 @@ paginate = 10
     default_sharing_image = "img/sharing-default.png"
 
     # Google Maps API key (if not set will default to not passing a key.)
+    enableGoogleMaps = false
     googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
 
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -83,6 +83,9 @@ paginate = 10
     enableGoogleMaps = true
     googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
 
+    latitude = "-12.043333"
+    longitude = "-77.028333"
+
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "default"
 
@@ -119,8 +122,6 @@ paginate = 10
         <strong>Great Britain</strong>
       </p>
       """
-    latitude = "-12.043333"
-    longitude = "-77.028333"
 
 [Permalinks]
     blog = "/blog/:year/:month/:day/:filename/"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -80,7 +80,7 @@ paginate = 10
     default_sharing_image = "img/sharing-default.png"
 
     # Google Maps API key (if not set will default to not passing a key.)
-    enableGoogleMaps = false
+    enableGoogleMaps = true
     googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
 
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -79,7 +79,7 @@ paginate = 10
     twitter_site = "GoHugoIO" # the Twitter handle of your site (without the '@')
     default_sharing_image = "img/sharing-default.png"
 
-    # Google Maps API key (if not set will default to not passing a key.)
+    # Google Maps widget: If `googleMapsApiKey` is not set, no key will be passed to Google (which likely results in a broken map widget).
     enableGoogleMaps = true
     googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,6 +6,7 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.1/jquery.waypoints.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/Counter-Up/1.0/jquery.counterup.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-parallax/1.1.3/jquery-parallax.js"></script>
+{{ if .Site.Params.enableGoogleMaps }}
 {{ if .Site.Params.googleMapsApiKey }}
 <script src="//maps.googleapis.com/maps/api/js?key={{.Site.Params.googleMapsApiKey}}&v=3.exp"></script>
 {{ else }}
@@ -13,6 +14,7 @@
 {{ end }}
 <script src="{{ "js/hpneo.gmaps.js" | relURL }}"></script>
 <script src="{{ "js/gmaps.init.js" | relURL }}"></script>
+{{ end }}
 <script src="{{ "js/front.js" | relURL }}"></script>
 
 <!-- owl carousel -->


### PR DESCRIPTION
hi, I add an var `enableGoogleMaps ` in  param.
it is mainly for if you do't want to use GoogleMaps, you can set it to 'false' or not set it.
if you want to use GoogleMaps, just set it in configure file under the param key.
