### PR TITLE
Add Stale PR action

### DIFF
--- a/stale.yml
+++ b/stale.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * 0"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'awaiting-approval,in-progress'
+        exempt-pr-labels: 'awaiting-approval,in-progress'


### PR DESCRIPTION
Should automatically close PRs older than 30 days, [more info here](https://github.com/actions/stale)

Users can ovveride the stale bot closing the ticket by replying with a comment.