### PR TITLE
fixed to Formspree new form style

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -97,13 +97,13 @@ paginate = 10
     #
     # - register your account to https://formspree.io/register
     # - login and create new form
-    # - set your form's endpoint under 'formspree_action' below (without https://formspree.io/ from https://formspree.io/sample/of/endpoint )
+    # - set your form's endpoint url under 'formspree_action' below
     # - upload the generated site to your server
     # - test a dummy email yourself
     # - you're done. Happy mailing!
     #
-    # Enable the contact form by entering your Formspree.io endpoint
-    formspree_action = "sample/of/endpoint"
+    # Enable the contact form by entering your Formspree.io endpoint url
+    formspree_action = "https://formspree.io/sample/of/endpoint"
     contact_form_ajax = false
 
     about_us = "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -91,18 +91,19 @@ paginate = 10
 
     # Since this template is static, the contact form uses www.formspree.io as a
     # proxy. The form makes a POST request to their servers to send the actual
-    # email. Visitors can send up to a 1000 emails each month for free.
+    # email. Visitors can send up to a 50 emails each month for free.
     #
     # What you need to do for the setup?
     #
-    # - set your email address under 'email' below
+    # - register your account to https://formspree.io/register
+    # - login and create new form
+    # - set your form's endpoint under 'endpoint' below (without https://formspree.io/ from https://formspree.io/ENDPOINT )
     # - upload the generated site to your server
-    # - send a dummy email yourself to confirm your account
-    # - click the confirm link in the email from www.formspree.io
+    # - test a dummy email yourself
     # - you're done. Happy mailing!
     #
-    # Enable the contact form by entering your Formspree.io email
-    email = "your@email.com"
+    # Enable the contact form by entering your Formspree.io endpoint
+    endpoint = "sample/of/endpoint"
     contact_form_ajax = false
 
     about_us = "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -97,13 +97,13 @@ paginate = 10
     #
     # - register your account to https://formspree.io/register
     # - login and create new form
-    # - set your form's endpoint under 'endpoint' below (without https://formspree.io/ from https://formspree.io/ENDPOINT )
+    # - set your form's endpoint under 'formspree_action' below (without https://formspree.io/ from https://formspree.io/sample/of/endpoint )
     # - upload the generated site to your server
     # - test a dummy email yourself
     # - you're done. Happy mailing!
     #
     # Enable the contact form by entering your Formspree.io endpoint
-    endpoint = "sample/of/endpoint"
+    formspree_action = "sample/of/endpoint"
     contact_form_ajax = false
 
     about_us = "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>"

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -7,7 +7,7 @@
 
                 {{ .Content }}
 
-                {{ if isset .Site.Params "endpoint" }}
+                {{ if isset .Site.Params "formspree_action" }}
 
                 <div class="heading">
                   <h3>{{ i18n "contactForm" }}</h3>
@@ -15,7 +15,7 @@
 
                 <div id="contact-message"></div>
 
-                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="https://formspree.io/{{ .Site.Params.endpoint }}">
+                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="https://formspree.io/{{ .Site.Params.formspree_action }}">
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -15,7 +15,7 @@
 
                 <div id="contact-message"></div>
 
-                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="https://formspree.io/{{ .Site.Params.formspree_action }}">
+                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="{{ .Site.Params.formspree_action }}">
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -7,7 +7,7 @@
 
                 {{ .Content }}
 
-                {{ if isset .Site.Params "email" }}
+                {{ if isset .Site.Params "endpoint" }}
 
                 <div class="heading">
                   <h3>{{ i18n "contactForm" }}</h3>
@@ -15,7 +15,7 @@
 
                 <div id="contact-message"></div>
 
-                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="https://formspree.io/{{ .Site.Params.email }}">
+                <form {{ with .Site.Params.contact_form_ajax }}class="contact-form-ajax"{{ else }}{{ end }} method="post" action="https://formspree.io/{{ .Site.Params.endpoint }}">
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">


### PR DESCRIPTION
I'm a user of hugo-universal-theme.

Last day, I updated my web site and tested contact form, then I got a email from Formspree that title is 'PLEASE UPDATE YOUR LEGACY FORMS'.

I checked Formspree website and I noticed Formspree encourage to migrate old style form to new style form.

https://help.formspree.io/hc/en-us/articles/360056076314-Phasing-out-legacy-forms-email-URLs-

Under my understanding old style form is HTML form action url with email address and new style's action url is a endpoint created by Formspree dashboard after you registered and login.

So I try to fix to Formspree new form style.

Best regards.