### PR TITLE
Add recent posts parameter to hide summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Then, you can enable the section in the configuration file.
 
 #### Recent posts
 
-The recent posts sections shows the four latest published blog posts, with their featured image and a summary. It defaults to show recent posts from all [main sections](https://gohugo.io/functions/where/#mainsections). This is either the section with the most posts or can be set explicitly in the configuration file (see linked docs).
+The recent posts sections shows the four latest published blog posts, with their featured image and an optional summary. It defaults to show recent posts from all [main sections](https://gohugo.io/functions/where/#mainsections). This is either the section with the most posts or can be set explicitly in the configuration file (see linked docs).
 
 You can enable it in the configuration file.
 
@@ -401,6 +401,7 @@ You can enable it in the configuration file.
     enable = true
     title = "From our blog"
     subtitle = "Pellen
+    hide_summary = false
 ```
 
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -182,3 +182,4 @@ paginate = 10
     enable = true
     title = "From our blog"
     subtitle = "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo."
+    hide_summary = false

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -43,10 +43,12 @@
                             {{ end }}
                             {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
                             </p>
+                            {{ if not .Site.Params.recent_posts.hide_summary }}
                             <p class="intro">{{ .Summary }}</p>
                             <p class="read-more">
                               <a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
                             </p>
+                            {{ end }}
                         </div>
                     </div>
                     <!-- /.box-image-text -->


### PR DESCRIPTION
Introduce a recent_posts.hide_summary flag to not show the contents
summary in the recent posts section.

Signed-off-by: Richard Leitner <dev@bubus.at>