### PR TITLE
harmonize config key capitalization

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -121,7 +121,7 @@ paginate = 10
     latitude = "-12.043333"
     longitude = "-77.028333"
 
-[Permalinks]
+[permalinks]
     blog = "/blog/:year/:month/:day/:filename/"
 
 # Enable or disable top bar with social icons


### PR DESCRIPTION
While TOML keys _are_ case-sensitive, [Hugo normalizes them to lower-case internally](https://discourse.gohugo.io/t/config-params-should-be-all-lowercase-or-not/5051/2), so capitalization doesn't really matter. Thus, this change is for the sake of consistency.