### PR TITLE
Improve e-mail field on contact page

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -26,7 +26,7 @@
                         <div class="col-sm-6">
                             <div class="form-group">
                                 <label for="email">{{ i18n "contactMail" }}</label>
-                                <input type="text" class="form-control" name="email" id="email" required>
+                                <input type="email" autocomplete="email" class="form-control" name="email" id="email" required>
                             </div>
                         </div>
                         <div class="col-sm-12">


### PR DESCRIPTION
Setting

- [`type="email"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email) allows clients to automatically validate the input to ensure that it's either empty or a properly-formatted e-mail address.
- [`autocomplete="email"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) allows clients to properly autocomplete the field (e-mail addresses only).