### PR TITLE
add correct link to author's page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -39,7 +39,7 @@
                                         <p class="author-category">
                                           {{ if isset .Params "author" }}
 					  {{ i18n "authorBy" }}
-					   <a href="{{ printf "/%s/%s" "authors" (.Params.author | urlize) }}">{{ .Params.author }}</a>
+					   <a href="{{ printf "%s/%s" ("authors" | relURL) (.Params.author | urlize) }}">{{ .Params.author }}</a>
                                           {{ end }}
                                           {{ if isset .Params "categories" }}
                                           {{ if gt (len .Params.categories) 0 }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -38,7 +38,8 @@
                                     <div class="clearfix">
                                         <p class="author-category">
                                           {{ if isset .Params "author" }}
-                                          {{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a>
+					  {{ i18n "authorBy" }}
+					   <a href="{{ printf "/%s/%s" "authors" (.Params.author | urlize) }}">{{ .Params.author }}</a>
                                           {{ end }}
                                           {{ if isset .Params "categories" }}
                                           {{ if gt (len .Params.categories) 0 }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -22,7 +22,9 @@
 
                         {{ if or .Params.author .Params.date }}
                           <p class="text-muted text-uppercase mb-small text-right">
-                            {{ if .Params.author }}{{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a>{{ end }}
+                            {{ if .Params.author }}{{ i18n "authorBy" }}
+			      <a href="{{ printf "/%s/%s" "authors" (.Params.author | urlize) }}">{{ .Params.author }}</a>
+			    {{ end }}
                             {{ if and .Params.author .Params.date }} | {{ end }}
                             {{ if .Params.date }}{{ .Date.Format .Site.Params.date_format }}{{ end }}
                           </p>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,7 +23,7 @@
                         {{ if or .Params.author .Params.date }}
                           <p class="text-muted text-uppercase mb-small text-right">
                             {{ if .Params.author }}{{ i18n "authorBy" }}
-			      <a href="{{ printf "/%s/%s" "authors" (.Params.author | urlize) }}">{{ .Params.author }}</a>
+			      <a href="{{ printf "%s/%s" ("authors" | relURL) (.Params.author | urlize) }}">{{ .Params.author }}</a>
 			    {{ end }}
                             {{ if and .Params.author .Params.date }} | {{ end }}
                             {{ if .Params.date }}{{ .Date.Format .Site.Params.date_format }}{{ end }}

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -39,7 +39,8 @@
                             <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
                             <p class="author-category">
                             {{ with .Params.author }}
-                            {{ i18n "authorBy" }} <a href="#">{{ . }}</a>
+                            {{ i18n "authorBy" }}
+			      <a href="{{ printf "/%s/%s" "authors" ( . | urlize) }}">{{ . }}</a>
                             {{ end }}
                             {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
                             </p>

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -40,7 +40,7 @@
                             <p class="author-category">
                             {{ with .Params.author }}
                             {{ i18n "authorBy" }}
-			      <a href="{{ printf "/%s/%s" "authors" ( . | urlize) }}">{{ . }}</a>
+			      <a href="{{ printf "%s/%s" ("authors" | relURL) ( . | urlize) }}">{{ . }}</a>
                             {{ end }}
                             {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
                             </p>


### PR DESCRIPTION
correctly link to an authors page instead to '#'.