### PR TITLE
Allow contact URL to be different for i18n

### DIFF
--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Adaptada a Hugo per"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Anar a la pàgina de contacte"
 

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Na Hugo přidal"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Přejít na stránku s kontakty"
 

--- a/i18n/da.yaml
+++ b/i18n/da.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Porteret til Hugo af"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Gå til kontaktside"
 

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Portiert nach Hugo durch"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Zur Kontaktseite"
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Ported to Hugo by"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Go to contact page"
 

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Adaptada a Hugo por"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Ir a la página de contacto"
 

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Porté sur Hugo par"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Aller à la page de contact"
 

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Diadapatasi ke Hugo oleh"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Ke laman kontak"
 

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Portato in Hugo da"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Vai alla pagina contatti"
 

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Hugo への移植"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "お問い合わせはこちら"
 

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Omgezet naar Hugo door"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Ga naar de contactpagina"
 

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Przeportowany do Hugo przez"
 
+- id: contactURL
+  translation: "kontakt"
+
 - id: contactGoTo
   translation: "Przejdź do strony kontaktu"
 

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Portado para o Hugo por"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Vá à página de contato"
 

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Portat în Hugo de"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Du-te la pagina de contact"
 

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Портирован на Hugo"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Страница контактов"
 

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "Portad till Hugo av"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "Gå till kontaktsidan"
 

--- a/i18n/zh-tw.yaml
+++ b/i18n/zh-tw.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "移植至 Hugo 源自"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "前往聯絡資訊"
 

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -7,6 +7,9 @@
 - id: portedBy
   translation: "移植到 Hugo 来自"
 
+- id: contactURL
+  translation: "contact"
+
 - id: contactGoTo
   translation: "跳到联系页面"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -50,7 +50,7 @@
 
             {{ .Site.Params.address | safeHTML }}
 
-            <a href="/contact" class="btn btn-small btn-template-main">{{ i18n "contactGoTo" }}</a>
+            <a href="{{ i18n "contactUrl" }}" class="btn btn-small btn-template-main">{{ i18n "contactGoTo" }}</a>
 
             <hr class="hidden-md hidden-lg hidden-sm">
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -50,7 +50,7 @@
 
             {{ .Site.Params.address | safeHTML }}
 
-            <a href="{{ i18n "contactUrl" }}" class="btn btn-small btn-template-main">{{ i18n "contactGoTo" }}</a>
+            <a href="{{ i18n "contactURL" }}" class="btn btn-small btn-template-main">{{ i18n "contactGoTo" }}</a>
 
             <hr class="hidden-md hidden-lg hidden-sm">
 


### PR DESCRIPTION
Make the contact URL not hardcoded to allow setting internationalized URLs.

It serves me my purpose, I added the default `contact` to all the languages except for Polish so each language would have to be adjusted to work differently than now, though on the second though, it might be better to allow to URL to be set as wish in `config.toml`, I might take a look at it later, but no promises, feel free to close this PR and remake it to a new one if this is deemed as a better approach.

I edited the files by hand using GitHub web interface, so the PR probably could use squashing if merged as-is to avoid extra commits.