### PR TITLE
Deprecation warning

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -36,7 +36,7 @@
                     {{ $active = "active" }}
                   {{ end }}
 
-                  {{ if and (or (eq $current.Permalink .URL) (eq "term" $current.Kind)) (in (slice "page" "term") $current.Kind) }}
+                  {{ if and (or (eq $current.RelPermalink .URL) (eq "term" $current.Kind)) (in (slice "page" "term") $current.Kind) }}
                     {{ range (split .URL "/") }}
                       {{ if eq "blog" . }}
                         {{ $active = "active" }}


### PR DESCRIPTION
Fixes this warning `WARN 2021/10/13 17:14:48 Page.URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url`