### PR TITLE
switch to relLangURL in navbar logo href

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,8 +1,8 @@
 <header class="navbar-affixed-top" data-spy="affix" data-offset-top="62">
-    <div class="navbar navbar-default yamm" role="navigation" id="navbar">    
+    <div class="navbar navbar-default yamm" role="navigation" id="navbar">
         <div class="container">
             <div class="navbar-header">
-                <a class="navbar-brand home" href="{{ "/" | relURL }}">
+                <a class="navbar-brand home" href="{{ "/" | relLangURL }}">
                     {{ if default false .Site.Params.disabled_logo }}
                       <h4>{{ .Site.Params.logo_text }}</h4>
                     {{ else }}
@@ -23,7 +23,7 @@
             <div class="navbar-collapse collapse" id="navigation">
                 <ul class="nav navbar-nav navbar-right">
                   {{ $current := . }}
-                  
+
                   {{ range .Site.Menus.main.ByWeight }}
                   {{ $topLevel := replace .URL "/" "" }}
                   {{ $active := "" }}
@@ -67,7 +67,7 @@
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>                                
+                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
                                     {{- end }}
                                     </ul>
                                     {{ end }}
@@ -82,7 +82,7 @@
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>                                
+                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
                                     {{ end }}
                                     </ul>
                                     {{ end }}
@@ -98,7 +98,7 @@
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>                                
+                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
                                     {{ end }}
                                     </ul>
                                     {{ end }}
@@ -113,7 +113,7 @@
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>                                
+                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
                                     {{ end }}
                                     </ul>
                                     {{ end }}
@@ -143,7 +143,7 @@
             </div>
             <!--/.nav-collapse -->
 
-            <div class="collapse clearfix" id="search">    
+            <div class="collapse clearfix" id="search">
                 <form class="navbar-form" role="search">
                     <div class="input-group">
                         <input type="text" class="form-control" placeholder="Search">


### PR DESCRIPTION
Clicking the logo in the navigation bar leads one to the main page of the default language.
Switch to `relLangURL` in the logo's `href` to switch to the main page of the currently viewed language.