### PR TITLE
Fix for issue #154 - Carousel item can be a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,37 @@ This Hugo theme was ported from [Bootstrapious](http://bootstrapious.com/p/unive
 
 ## Table of Contents
 
-* [Features](#features)
-* [Installation](#installation)
-* [Configuration](#configuration)
-  * [Style](#style)
-  * [Comments](#comments)
-  * [Google Analytics](#google-analytics)
-  * [Contact form](#contact-form)
-  * [Menu](#menu)
-  * [Sidebar widgets](#sidebar-widgets)
-  * [Blog post thumbnails](#blog-post-thumbnails)
-  * [Top bar](#top-bar)
-  * [Landing page](#landing-page)
-    * [Carousel](#carousel)
-    * [Features](#features)
-    * [Testimonials](#testimonials)
-    * [See more](#see-more)
-    * [Clients](#clients)
-    * [Recent posts](#recent-posts)
-    * [Footer](#footer)
-  * [Meta tags](#meta-tags)
-* [Usage](#usage)
-* [Contributing](#contributing)
-* [License](#license)
-* [Thanks](#thanks)
+- [Universal Theme for Hugo](#universal-theme-for-hugo)
+  - [Table of Contents](#table-of-contents)
+  - [Features](#features)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+    - [Language](#language)
+    - [Style](#style)
+    - [Comments](#comments)
+    - [Google Analytics](#google-analytics)
+    - [Logo](#logo)
+    - [Contact form](#contact-form)
+    - [Menu](#menu)
+    - [Sidebar widgets](#sidebar-widgets)
+    - [Top bar](#top-bar)
+    - [Blog post thumbnails](#blog-post-thumbnails)
+    - [Landing page](#landing-page)
+      - [Carousel](#carousel)
+      - [Features](#features-1)
+      - [Testimonials](#testimonials)
+      - [See more](#see-more)
+      - [Clients](#clients)
+      - [Recent posts](#recent-posts)
+      - [Footer](#footer)
+        - [About us](#about-us)
+        - [Recent posts](#recent-posts-1)
+        - [Contact](#contact)
+    - [Meta tags](#meta-tags)
+  - [Usage](#usage)
+  - [Contributing](#contributing)
+  - [License](#license)
+  - [Thanks](#thanks)
 
 ## Features
 
@@ -377,9 +384,10 @@ description: >
     <li>Easily to change fonts</li>
   </ul>
 image: "img/carousel/template-easy-code.png"
+href: "https://devcows.github.io/hugo-universal-theme/"
 ```
 
-The `weight` field determines the position of the entry. `title` is a text-only field. The `description` field accepts HTML code. And the `image` must contain the relative path to the image inside the `static` directory.
+The `weight` field determines the position of the entry. `title` is a text-only field. The `description` field accepts HTML code. The `image` must contain the relative path to the image inside the `static` directory. The optional `href` field contains a relative or absolute url that the user will be redirected to when clicking the carousel (specific to each carousel item).
 
 Once the carousel is configured, some options can be defined like: auto play, speed, etc. in the `config.toml` file.
 

--- a/exampleSite/data/carousel/customizable.yaml
+++ b/exampleSite/data/carousel/customizable.yaml
@@ -6,3 +6,4 @@ description: >
     <li>Easily to change fonts</li>
   </ul>
 image: "img/carousel/template-easy-code.png"
+href: "https://devcows.github.io/hugo-universal-theme/"

--- a/exampleSite/data/carousel/features.yaml
+++ b/exampleSite/data/carousel/features.yaml
@@ -8,4 +8,4 @@ description: >
      <li>+ 11 extra pages showing template features</li>
    </ul>
 image: "img/carousel/template-mac.png"
-href: "/faq"
+href: "faq"

--- a/exampleSite/data/carousel/features.yaml
+++ b/exampleSite/data/carousel/features.yaml
@@ -8,3 +8,4 @@ description: >
      <li>+ 11 extra pages showing template features</li>
    </ul>
 image: "img/carousel/template-mac.png"
+href: "/faq"

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -1,4 +1,4 @@
-{{ if default true .Site.Params.CarouselHomepage.enable }}
+i{{ if default true .Site.Params.CarouselHomepage.enable }}
 {{ if gt (len .Site.Data.carousel) 0 }}
 <section>
     <div class="home-carousel">
@@ -10,15 +10,21 @@
                 data-pagination-speed="{{ default 1000 .Site.Params.CarouselHomepage.pagination_speed }}">
                 {{ range sort .Site.Data.carousel "weight" }}
                 <div class="item">
-                    <div class="row">
-                        <div class="col-sm-5 right">
-                            <h1>{{ .title }}</h1>
-                            {{ .description | safeHTML }}
+                    {{ if .href }}
+                    <a href="{{ .href }}">
+                    {{ end }}
+                        <div class="row">
+                            <div class="col-sm-5 right">
+                                <h1>{{ .title }}</h1>
+                                {{ .description | safeHTML }}
+                            </div>
+                            <div class="col-sm-7">
+                                <img class="img-responsive" src="{{ .image }}" alt="">
+                            </div>
                         </div>
-                        <div class="col-sm-7">
-                            <img class="img-responsive" src="{{ .image }}" alt="">
-                        </div>
-                    </div>
+                    {{ if .href }}
+                    </a>
+                    {{ end }}
                 </div>
                 {{ end }}
             </div>

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -1,4 +1,4 @@
-i{{ if default true .Site.Params.CarouselHomepage.enable }}
+{{ if default true .Site.Params.CarouselHomepage.enable }}
 {{ if gt (len .Site.Data.carousel) 0 }}
 <section>
     <div class="home-carousel">


### PR DESCRIPTION
Added a .href item to look for in the md. .href can be an item in it's own right of provide an href for the entire carousel item.

This commit updated the carousel.html partial to look for the above .href in the md. If it's there it creates a link for the entire carousel owl-item. If it doesn't then buisness as usual.