### PR TITLE
Use hide_summary also for blogs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ summaryLength = 70
 ```
 
 Recent posts use `.Summary` property and by default, Hugo automatically takes the first 70 words of your content as its summary and stores it into the `.Summary` page variable for use in your templates. You may customize the summary length by setting summaryLength in your site configuration.
+When setting the `hide_summary` configuration property to `true` the summary will be hidden on the recent posts as well as the blogs list page.
 
 #### Footer
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -64,9 +64,11 @@
                                         </p>
                                         {{ end }}
                                     </div>
+                                    {{ if not .Site.Params.recent_posts.hide_summary }}
                                     <p class="intro">{{ .Summary }}</p>
                                     <p class="read-more"><a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
                                     </p>
+                                    {{ end }}
                                 </div>
                             </div>
                         </section>


### PR DESCRIPTION
Apply the `recent_posts.hide_summary` flag introduced in https://github.com/devcows/hugo-universal-theme/pull/283 also to the default blog list.

Signed-off-by: Richard Leitner <dev@bubus.at>