### PR TITLE
Add trailing slash for categories and tags links

### DIFF
--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -12,7 +12,7 @@
             {{ $current := . }}
             {{ range $name, $items := .Site.Taxonomies.categories }}
             <li{{ if eq $current.RelPermalink ($name | urlize | lower | printf "/categories/%s/") }} class="active"{{ end }}>
-                <a href="{{ "categories/" | relLangURL }}{{ $name | urlize | lower }}">{{ $name | upper }} ({{ len $items }})</a>
+                <a href="{{ "categories/" | relLangURL }}{{ $name | urlize | lower }}/">{{ $name | upper }} ({{ len $items }})</a>
             </li>
             {{ end }}
         </ul>

--- a/layouts/partials/widgets/tags.html
+++ b/layouts/partials/widgets/tags.html
@@ -12,7 +12,7 @@
             {{ $current := . }}
             {{ range $name, $items := .Site.Taxonomies.tags }}
             <li {{ if eq $current.RelPermalink (printf "%s/%s/" ("tags" | relLangURL) ($name | urlize | lower)) }}class="active"{{ end }}>
-                <a href="{{ "tags/" | relLangURL }}{{ $name | urlize | lower }}"><i class="fas fa-tags"></i> {{ $name }}</a>
+                <a href="{{ "tags/" | relLangURL }}{{ $name | urlize | lower }}/"><i class="fas fa-tags"></i> {{ $name }}</a>
             </li>
             {{ end }}
         </ul>


### PR DESCRIPTION
There are 308 redirects on links because Hugo expects trailing slash.