### PR TITLE
Add hide_image feature for recent posts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,10 +549,12 @@ summaryLength = 70
     title = "From our blog"
     subtitle = "Pellen"
     hide_summary = false
+    hide_image = false
 ```
 
 Recent posts use `.Summary` property and by default, Hugo automatically takes the first 70 words of your content as its summary and stores it into the `.Summary` page variable for use in your templates. You may customize the summary length by setting summaryLength in your site configuration.
 When setting the `hide_summary` configuration property to `true` the summary will be hidden on the recent posts as well as the blogs list page.
+And also if you set `hide_image` configuration property to `true` the image will be hidden like `hide_summary`.
 
 #### Footer
 
@@ -569,11 +571,12 @@ A text can be defined, in case there is no text defined the entire block will be
 
 ##### Recent posts
 
-Recent posts block can be enabled or disabled (hidden).
+Recent posts block can be enabled or disabled (hidden). And you can use `hide_iamge` for `Recent posts` block on footer.
 
 ```toml
 [params.footer.recent_posts]
     enable = true
+    hide_image = false
 ```
 
 ##### Contact

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -541,9 +541,11 @@ pluralizelisttitles = false
     title = "From our blog"
     subtitle = "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo."
     hide_summary = false
+    hide_image = false
 
 [params.footer.recent_posts]
     enable = true
+    hide_image = false
 
 [taxonomies]
   category = "categories"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -27,6 +27,7 @@
                         {{ range $paginator.Pages }}
                         <section class="post">
                             <div class="row">
+                                {{ if not (default false .Site.Params.recent_posts.hide_image) }}
                                 <div class="col-md-4">
                                   <div class="image">
                                       <a href="{{ .Permalink }}">
@@ -39,7 +40,10 @@
                                   </div>
                                 </div>
                                 <div class="col-md-8">
-                                    <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+                                {{ else }}
+                                <div class="col-md-12">
+                                {{ end }}
+                                        <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
                                     <div class="clearfix">
                                         <p class="author-category">
                                           {{ if isset .Params "authors" }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,6 +21,7 @@
             <div class="blog-entries">
                 {{ range first 3 (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
                 <div class="item same-height-row clearfix">
+                    {{ if not (default false .Site.Params.footer.recent_posts.hide_image) }}
                     <div class="image same-height-always">
                         <a href="{{ .Permalink }}">
                           {{ if isset .Params "banner" }}
@@ -30,6 +31,7 @@
                           {{ end }}
                         </a>
                     </div>
+                    {{ end }}
                     <div class="name same-height-always">
                         <h5><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
                     </div>

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -19,6 +19,7 @@
                 {{ range first 4 $posts.Pages }}
                 <div class="col-md-3 col-sm-6">
                     <div class="box-image-text blog">
+                        {{ if not (default false .Site.Params.recent_posts.hide_image) }}
                         <div class="top">
                             <div class="image" style="overflow:hidden">
                                 {{ if isset .Params "banner" }}
@@ -34,6 +35,7 @@
                                 </p>
                             </div>
                         </div>
+                        {{ end }}
 
                         <div class="content">
                             <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>


### PR DESCRIPTION
To support text-only posts, I propose to add a configuration property `hide_image` to hide an image in `recent posts`, referring to `hide_summary`.

Also the `recent posts` block in the footer has an independent `enable` property, so I added a separate `hide_image` property here as well.

Please check this PR.

Best regards.