### PR TITLE
Fix quoting in partials/headers.html

### DIFF
--- a/layouts/partials/headers.html
+++ b/layouts/partials/headers.html
@@ -4,12 +4,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {{ $title_plain := .Title | markdownify | plainify }}
 <title>{{ $title_plain }}</title>
-<meta name="author" content="{{ .Param "author" }}" />
+<meta name="author" content='{{ .Param "author" }}' />
 {{ $keywords := .Site.Params.defaultKeywords | default (slice "" | first 0) }}
 {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
 {{ if isset .Params "keywords" }}{{ range .Params.keywords }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}
 {{ if gt (len $keywords) 0 }}
-<meta name="keywords" content="{{ delimit (uniq $keywords) ", " }}">
+<meta name="keywords" content='{{ delimit (uniq $keywords) ", " }}'>
 {{ end }}
 {{ $description_plain := default .Site.Params.defaultDescription .Description | markdownify | plainify }}
 <meta name="description" content="{{ $description_plain }}">
@@ -24,17 +24,17 @@
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
 <!-- CSS animations  -->
-<link href="{{ "css/animate.css" | relURL }}" rel="stylesheet">
+<link href='{{ "css/animate.css" | relURL }}' rel="stylesheet">
 
 <!-- Theme stylesheet, if possible do not edit this stylesheet -->
 {{ with .Site.Params.style }}
-  <link href="{{ "css/style" | relURL }}.{{ . }}.css" rel="stylesheet" id="theme-stylesheet">
+  <link href='{{ "css/style" | relURL }}.{{ . }}.css' rel="stylesheet" id="theme-stylesheet">
 {{ else }}
-  <link href="{{ "css/style.default.css" | relURL }}" rel="stylesheet" id="theme-stylesheet">
+  <link href='{{ "css/style.default.css" | relURL }}' rel="stylesheet" id="theme-stylesheet">
 {{ end }}
 
 <!-- Custom stylesheet - for your changes -->
-<link href="{{ "css/custom.css" | relURL }}?{{ now.Unix }}" rel="stylesheet">
+<link href='{{ "css/custom.css" | relURL }}?{{ now.Unix }}' rel="stylesheet">
 
 <!-- Responsivity for older IE -->
 {{ `
@@ -45,15 +45,15 @@
 ` | safeHTML }}
 
 <!-- Favicon and Apple touch icons-->
-<link rel="shortcut icon" href="{{ "img/favicon.ico" | relURL }}" type="image/x-icon" />
-<link rel="apple-touch-icon" href="{{ "img/apple-touch-icon.png" | relURL }}" />
+<link rel="shortcut icon" href='{{ "img/favicon.ico" | relURL }}' type="image/x-icon" />
+<link rel="apple-touch-icon" href='{{ "img/apple-touch-icon.png" | relURL }}' />
 
 <!-- owl carousel CSS -->
-<link href="{{ "css/owl.carousel.css" | relURL }}" rel="stylesheet">
-<link href="{{ "css/owl.theme.css" | relURL }}" rel="stylesheet">
+<link href='{{ "css/owl.carousel.css" | relURL }}' rel="stylesheet">
+<link href='{{ "css/owl.theme.css" | relURL }}' rel="stylesheet">
 
 <!-- RSS feed -->
-<link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
+<link rel="alternate" href='{{ "/index.xml" | absURL }}' type="application/rss+xml" title="{{ .Site.Title }}">
 
 <!-- Facebook OpenGraph tags -->
 {{ $is_blog := and (eq .Type "blog") (eq .Kind "page") }}
@@ -62,14 +62,15 @@
 {{ $is_valid_image := print "static/" $image | fileExists }}
 {{ if $is_valid_image }}
 {{ $image_ext := path.Ext $image }}
-<meta property="og:locale" content="{{ replace .Site.LanguageCode "-" "_" }}">
+<meta property="og:locale" content='{{ replace .Site.LanguageCode "-" "_" }}'>
 <meta property="og:site_name" content="{{ .Site.Title }}">
 <meta property="og:title" content="{{ $title_plain }}">
-<meta property="og:type" content="{{ cond $is_blog "article" "website" }}">
+<meta property="og:type" content='{{ cond $is_blog "article" "website" }}'>
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:description" content="{{ $description_plain }}">
 <meta property="og:image" content="{{ $image | absURL }}">
-<meta property="og:image:type" content="image/{{ if eq $image_ext ".svg" }}svg+xml{{ else }}{{ trim $image_ext "." }}{{ end }}">
+<meta property="og:image:type"
+  content='image/{{ if eq $image_ext ".svg" }}svg+xml{{ else }}{{ trim $image_ext "." }}{{ end }}'>
 {{ with .Params.banner_alt }}<meta property="og:image:alt" content="{{ . | markdownify | plainify }}">{{ end }}
 {{ $image_local :=  printf "/static/%s" $image}}
 {{ with (imageConfig $image_local) }}
@@ -82,11 +83,18 @@
   {{ with .Param "facebook_site" }}<meta property="article:publisher" content="https://www.facebook.com/{{ . }}/">{{ end }}
   {{ with .Param "facebook_author" }}<meta property="article:author" content="https://www.facebook.com/{{ . }}/">{{ end }}
   {{ with .Params.categories }}<meta property="article:section" content="{{ index . 0 }}">{{ end }}
-  {{ range .Params.tags }}<meta property="article:tag" content="{{ . }}">
+  {{ range .Params.tags }}
+  <meta property="article:tag" content="{{ . }}">
   {{ end }}
-  {{ if gt .ExpiryDate .PublishDate }}<meta property="article:expiration_time" content="{{ .ExpiryDate.Format "2006-01-02T15:04:05Z0700" }}">{{ end }}
-  {{ with .PublishDate }}<meta property="article:published_time" content="{{ .Format "2006-01-02T15:04:05Z0700" }}">{{ end }}
-  {{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Format "2006-01-02T15:04:05Z0700" }}">{{ end }}
+  {{ if gt .ExpiryDate .PublishDate }}
+  <meta property="article:expiration_time" content='{{ .ExpiryDate.Format "2006-01-02T15:04:05Z0700" }}'>
+  {{ end }}
+  {{ with .PublishDate }}
+  <meta property="article:published_time" content='{{ .Format "2006-01-02T15:04:05Z0700" }}'>
+  {{ end }}
+  {{ with .Lastmod }}
+  <meta property="article:modified_time" content='{{ .Format "2006-01-02T15:04:05Z0700" }}'>
+  {{ end }}
 {{ end }}
 
 <!-- Twitter Card meta tags -->


### PR DESCRIPTION
Double quotes inside the templating pieces were short-circuiting the surrounding double quotes

This was causing issues with content being generated for me. Very curious how this isn't affecting anyone else.

This is what it looks like in my vscode:

<img width="1166" alt="Screenshot 2022-12-28 at 9 31 33 PM" src="https://user-images.githubusercontent.com/35014/209900219-7163c3fe-92c5-4354-bb1e-a8bafd1b74eb.png">
