### PR TITLE
add the option to translate menus' names using i18n

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -48,7 +48,7 @@
                     <!-- Check if the first child marks a menu section identifier -->
                     {{ $hasSections := (hasPrefix (index .Children 0).Identifier "section.") }}
                     <li class="dropdown{{ if $hasSections }} use-yamm yamm-fw{{end}} {{ $active }}">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ i18n .Identifier | default .Name}} <span class="caret"></span></a>
                         {{ if $hasSections }}
                         <ul class="dropdown-menu">
                             <li>
@@ -63,11 +63,11 @@
                                 {{ range .Children.ByWeight }}
                                     {{ $column := printf "%s" .Post }}
                                     {{ if eq $column "1" }}
-                                    <h5>{{ .Name }}</h5>
+                                    <h5>{{ i18n .Identifier | default .Name}}</h5>
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                                    <li><a href="{{ .URL }}">{{ i18n .Identifier | default .Name}}</a></li>
                                     {{- end }}
                                     </ul>
                                     {{ end }}
@@ -78,11 +78,11 @@
                                 {{ range .Children.ByWeight }}
                                     {{ $column := printf "%s" .Post }}
                                     {{ if eq $column "2" }}
-                                    <h5>{{ .Name }}</code></h5>
+                                    <h5>{{ i18n .Identifier | default .Name}}</code></h5>
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                                    <li><a href="{{ .URL }}">{{ i18n .Identifier | default .Name}}</a></li>
                                     {{ end }}
                                     </ul>
                                     {{ end }}
@@ -94,11 +94,11 @@
                                 {{ range .Children }}
                                     {{ $column := printf "%s" .Post }}
                                     {{ if eq $column "3" }}
-                                    <h5>{{ .Name }}</code></h5>
+                                    <h5>{{ i18n .Identifier | default .Name}}</code></h5>
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                                    <li><a href="{{ .URL }}">{{ i18n .Identifier | default .Name}}</a></li>
                                     {{ end }}
                                     </ul>
                                     {{ end }}
@@ -109,11 +109,11 @@
                                 {{ range .Children }}
                                     {{ $column := printf "%s" .Post }}
                                     {{ if eq $column "4" }}
-                                    <h5>{{ .Name }}</code></h5>
+                                    <h5>{{ i18n .Identifier | default .Name}}</code></h5>
                                     {{ if .HasChildren }}
                                     <ul>
                                     {{ range .Children.ByWeight }}
-                                    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                                    <li><a href="{{ .URL }}">{{ i18n .Identifier | default .Name}}</a></li>
                                     {{ end }}
                                     </ul>
                                     {{ end }}
@@ -128,14 +128,14 @@
                         {{ else }}
                         <ul class="dropdown-menu">
                             {{ range .Children.ByWeight }}
-                            <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                            <li><a href="{{ .URL }}">{{ i18n .Identifier | default .Name}}</a></li>
                             {{ end }}
                         </ul>
                         {{ end }}
                     </li>
                   {{ else }}
                   <li class="dropdown {{ $active }}">
-                    <a href="{{ .URL }}">{{ .Name }}</a>
+                    <a href="{{ .URL }}">{{ i18n .Identifier | default .Name}}</a>
                   </li>
                   {{ end }}
                   {{ end }}


### PR DESCRIPTION
With this change, we can add in `<root-project>/i18n/<desired-language>.yaml` the respective menu translation

For example, let's use the **exampleSite** in this repo

in `exampleSite/config.toml` I'll use Spanish

```toml
defaultContentLanguage = "es"
```

then I create `exampleSite/i18n/es.yaml` file, with the following content
```yaml
- id: menu.home
  translation: Inicio

- id: menu.features
  translation: Caracteristicas

- id: menu.portfolio
  translation: Portafolio

- id: section.about
  translation: Acerca de Nosotros
```

We only need the identifier property in the menu definition in the configuration, thus to translate more sub menus and items, we can add the property

in `exampleSite/config.toml` I'll add the property to `packages`
```toml
[[menu.main]]
    name       = "Packages"
    identifier = "item.packages" # new line
    url        = ""
    weight     = 1
    parent     = "section.marketing"
```
then I'll add the new translation in `exampleSite/i18n/es.yaml`
```yaml
- id: item.packages
  translation: Paquetes
```

When there isn't a translation for an ID, it just keeps the name set in the configuration