### PR TITLE
[fix] responsive image support for Markdown Post

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,4 @@
+{{/* responsive image support for Markdown Post */}}
+<p>
+    <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" class="img-responsive center-block" {{ with .Title }} title="{{ . }}"{{ end }} />
+</p>


### PR DESCRIPTION
If we add an image to a post **without the right sidebar** (e.g. [the FAQ page in the demo](https://devcows.github.io/hugo-universal-theme/faq/)), the image will not resize automatically as the window size changes.

![image](https://github.com/devcows/hugo-universal-theme/assets/75373727/67439da9-2109-4493-b044-77a478bffe3e)

I fix this by adding a Hugo "Markdown render hooks" for markdown image. Reference: https://gohugo.io/templates/render-hooks/#image-markdown-example

The image will render correctly with this file added.

![image](https://github.com/devcows/hugo-universal-theme/assets/75373727/637c258b-1ba0-40e6-b290-6db3c73be4ec)

Note: Posts **with the right sidebar** do render images correctly, even without this render hook (e.g. [this post in demo](https://devcows.github.io/hugo-universal-theme/blog/2021/08/01/categories-post/)).
