### PR TITLE
Fix deprecation warnings emitted by hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ There is the possibility to override the CSS and set your custom styles, overrid
 The optional comments system is powered by [Disqus](https://disqus.com). If you want to enable comments, create an account in Disqus and write down your shortname.
 
 ```toml
-disqusShortname = "devcows"
+[services]
+[services.disqus]
+Shortname = "devcows"
 ```
 
-You can disable the comments system by leaving the `disqusShortname` empty.
+You can disable the comments system by leaving the `Shortname` empty.
 
 
 ### Google Analytics
@@ -124,10 +126,12 @@ You can disable the comments system by leaving the `disqusShortname` empty.
 You can optionally enable Google Analytics. Type your tracking code in the ``.
 
 ```toml
-googleAnalytics = "UA-XXXXX-X"
+[services]
+[services.googleAnalytics]
+id = "UA-XXXXX-X"
 ```
 
-Leave the `googleAnalytics` key empty to disable it.
+Leave the `id` key empty to disable it.
 
 ### Logo
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,10 +5,6 @@ themesDir = "../.."
 languageCode = "en-us"
 # Site language. Available translations in the theme's `/i18n` directory.
 defaultContentLanguage = "en"
-# Enable comments by entering your Disqus shortname
-disqusShortname = "devcows"
-# Enable Google Analytics by entering your tracking code
-googleAnalytics = ""
 
 # number of words of summarized post content (default 70)
 summaryLength = 70
@@ -19,8 +15,15 @@ paginate = 10
 # not pluralize title pages by default
 pluralizelisttitles = false
 
-[menu]
+[services]
+[services.disqus]
+# Enable comments by entering your Disqus shortname
+Shortname = "devcows"
+[services.googleAnalytics]
+# Enable Google Analytics by entering your tracking code
+id = ""
 
+[menu]
 
 # Main menu
 [[menu.main]]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -45,7 +45,7 @@
                           {{ .Content }}
                         </div>
                         <!-- /#post-content -->
-                        {{ if .Site.DisqusShortname }}
+                        {{ if .Site.Config.Services.Disqus.Shortname }}
                         <div id="comments">
                             {{ template "_internal/disqus.html" . }}
                         </div>

--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
       {{ .Content }}
-      {{ if .Site.DisqusShortname }}
+      {{ if .Site.Config.Services.Disqus.Shortname }}
         <div class="disqus-comments">
         {{ template "_internal/disqus.html" . }}
         </div>


### PR DESCRIPTION
When running example site with latest hugo version 0.123.8, a deprecation warning is printed out:

```
INFO  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0
and will be removed in a future release.
Use .Site.Config.Services.Disqus.Shortname instead.
```

This PR fixes this issue.