### PR TITLE
fix: bootstrapious URL update

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -76,7 +76,7 @@ _________________________________________________________ -->
             <p class="pull-left">{{ .Site.Params.copyright | safeHTML }}</p>
             {{ end }}
             <p class="pull-right">
-              {{ i18n "templateBy" | markdownify }} <a href="https://bootstrapious.com/p/universal-business-e-commerce-template">Bootstrapious</a>.
+              {{ i18n "templateBy" | markdownify }} <a href="https://bootstrapious.com/universal-business-e-commerce-template">Bootstrapious</a>.
               <!-- Not removing this link is part of the licence conditions of the template. Thanks for understanding :) -->
 
               {{ i18n "portedBy" | markdownify }} <a href="https://github.com/devcows/hugo-universal-theme">DevCows</a>.


### PR DESCRIPTION
`https://bootstrapious.com/p/universal-business-e-commerce-template` returns 404:
![image](https://github.com/user-attachments/assets/383df1af-caac-43fe-af48-2b2c47cc136d)

`https://bootstrapious.com/universal-business-e-commerce-template` works:
![image](https://github.com/user-attachments/assets/abe04058-f5a6-4534-98aa-7084558cdd86)