### PR TITLE
#434 - contact.md needs type page

### DIFF
--- a/exampleSite/content/contact.md
+++ b/exampleSite/content/contact.md
@@ -1,6 +1,7 @@
 +++
 title = "Contact"
 id = "contact"
+type = "page"
 +++
 
 # We are here to help you


### PR DESCRIPTION
As I copied contact.md from the example site in to /content/contact.md, the contact form and map were missing
After investigation, the _default/single.html was being used instead of page/single.html
Solution is to set type = "page" in contact.md front matter