### PR TITLE
Fixed deprecation

### DIFF
--- a/exampleSite/content/blog/creating-a-new-theme.md
+++ b/exampleSite/content/blog/creating-a-new-theme.md
@@ -991,7 +991,7 @@ Knowing that hugo is using the slug to generate the file name, the simplest solu
 $ vi config.toml
 [permalinks]
   page = "/:title/"
-  about = "/:filename/"
+  about = "/:contentbasename/"
 ```
 
 Generate the web site and verify that this didn't work. Hugo lets "slug" or "URL" override the permalinks setting in the configuration file. Go ahead and comment out the slug in content/about.md, then generate the web site to get it to be created in the right place.

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -470,7 +470,7 @@ pluralizelisttitles = false
       """
 
 [permalinks]
-    blog = "/blog/:year/:month/:day/:filename/"
+    blog = "/blog/:year/:month/:day/:contentbasename/"
 
 # Enable or disable top bar with social icons
 [params.topbar]


### PR DESCRIPTION
WARN  deprecated: the ":filename" permalink token was deprecated in Hugo 0.144.0 and will be removed in a future release. Use ":contentbasename" instead.