### PR TITLE
Fix topbar text not vertically centered with social icons

### DIFF
--- a/static/css/style.blue.css
+++ b/static/css/style.blue.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.default.css
+++ b/static/css/style.default.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.green.css
+++ b/static/css/style.green.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.marsala.css
+++ b/static/css/style.marsala.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.pink.css
+++ b/static/css/style.pink.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.red.css
+++ b/static/css/style.red.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.turquoise.css
+++ b/static/css/style.turquoise.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;

--- a/static/css/style.violet.css
+++ b/static/css/style.violet.css
@@ -247,6 +247,10 @@ ul.list-style-none {
   color: #eeeeee;
   padding: 10px 0;
 }
+#top .row {
+  display: flex;
+  align-items: center;
+}
 #top p {
   margin: 0;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- Adds `#top .row { display: flex; align-items: center; }` to all 8 `style.*.css` variants
- The topbar social icon `<a>` tags are taller than the text line-height, causing the left-column text to sit at the top of the row rather than being vertically centered
- Uses proper CSS (flexbox) rather than padding hacks for robust vertical alignment

## Test plan
- [x] Run `hugo server` with topbar enabled (`[params.topbar]` in config)
- [x] Verify topbar text is vertically centered with the social icons at desktop width
- [x] Verify no layout breakage at mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)