### PR TITLE
Sanitize blog summaries with plainify and truncate

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -67,7 +67,7 @@
                                         {{ end }}
                                     </div>
                                     {{ if not .Site.Params.recent_posts.hide_summary }}
-                                    <p class="intro">{{ .Summary }}</p>
+                                    <p class="intro">{{ .Summary | plainify | truncate 300 }}</p>
                                     <p class="read-more"><a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
                                     </p>
                                     {{ end }}

--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -50,7 +50,7 @@
                             {{ end }}
                             </p>
                             {{ if not .Site.Params.recent_posts.hide_summary }}
-                            <p class="intro">{{ .Summary }}</p>
+                            <p class="intro">{{ .Summary | plainify | truncate 150 }}</p>
                             <p class="read-more">
                               <a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
                             </p>


### PR DESCRIPTION
## Summary
- Applies `| plainify | truncate` to `.Summary` in `recent_posts.html` (150 chars) and `list.html` (300 chars)
- Raw `.Summary` can emit HTML tags into card previews and list pages, breaking the layout with unclosed tags or unexpected markup
- `plainify` strips HTML, `truncate` ensures consistent card heights

## Test plan
- [x] Create a blog post with rich HTML content (images, links, bold text, code blocks)
- [x] Verify the homepage "Recent Posts" section shows clean plain-text previews (no HTML leaking)
- [x] Verify the blog list page (`/blog/`) also shows clean summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)