### PR TITLE
Fix 404 page broken assets on deep URLs with base tag

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
 
   <head>
+    <base href="{{ .Site.BaseURL }}">
     {{ partial "headers.html" . }}
     {{ partial "custom_headers.html" . }}
   </head>
@@ -24,7 +25,7 @@
                         <h3>{{ i18n "404Message" | markdownify }}</h3>
                         <h4 class="text-muted">{{ i18n "404Error" | markdownify }}</h4>
 
-                        <p class="buttons"><a href="{{ "/" | relURL }}" class="btn btn-template-main"><i class="fas fa-home"></i> {{ i18n "404NavHome" | markdownify }}</a>
+                        <p class="buttons"><a href="{{ "/" | absURL }}" class="btn btn-template-main"><i class="fas fa-home"></i> {{ i18n "404NavHome" | markdownify }}</a>
                         </p>
                     </div>
 


### PR DESCRIPTION
## Summary
- Adds `<base href="{{ .Site.BaseURL }}">` to `404.html` `<head>`
- Changes the home button link from `relURL` to `absURL`

## Problem
When a user hits a deep non-existent path like `/blog/2025/12/10/nonexistent/`, the 404 page is served from that path. Without a `<base>` tag, the browser resolves all relative URLs (CSS, JS, images, nav links) against that deep path — breaking the entire page layout.

This is the root cause behind issues like #141 (wrong URLs with double slashes) and #330 (404 on fresh install), where relative URL resolution fails depending on the serving path.

## Fix
The `<base>` tag tells the browser to resolve all relative URLs against the site's base URL instead of the current path. This is the standard HTML solution for pages served from unpredictable paths.

## Test plan
- [x] Run `hugo server` and navigate to a deep non-existent URL (e.g., `/some/deep/fake/path/`)
- [x] Verify the 404 page renders correctly with CSS, images, and navigation intact
- [x] Verify the "Go Home" button links to the site root

🤖 Generated with [Claude Code](https://claude.com/claude-code)