### PR TITLE
SEO: Append site title to page title tags

### DIFF
--- a/layouts/partials/headers.html
+++ b/layouts/partials/headers.html
@@ -3,7 +3,7 @@
 <meta name="googlebot" content="index,follow,snippet,archive">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {{ $title_plain := .Title | markdownify | plainify }}
-<title>{{ $title_plain }}</title>
+<title>{{ $title_plain }}{{ if not .IsHome }} | {{ .Site.Title }}{{ end }}</title>
 <meta name="author" content="{{ .Param "author" }}" />
 {{ $keywords := .Site.Params.defaultKeywords | default (slice "" | first 0) }}
 {{ if isset .Params "tags" }}{{ range .Params.tags }}{{ $keywords = $keywords | append . }}{{ end }}{{ end }}


### PR DESCRIPTION
## Summary
- Appends ` | {Site.Title}` to all non-homepage `<title>` tags
- Improves SERP branding and click-through rates
- No change on the homepage (keeps just the site title)

## Before / After
- Before: `<title>My Blog Post</title>`
- After: `<title>My Blog Post | My Site Name</title>`

## Test plan
- [x] Verify homepage title is unchanged
- [x] Verify inner pages show `Page Title | Site Title`
- [x] Run example site with `hugo server` and inspect `<title>` tags