### PR TITLE
Fix CSS cache-busting that prevented browser caching

### DIFF
--- a/layouts/partials/headers.html
+++ b/layouts/partials/headers.html
@@ -34,7 +34,7 @@
 {{ end }}
 
 <!-- Custom stylesheet - for your changes -->
-<link href="{{ "css/custom.css" | relURL }}?{{ now.Unix }}" rel="stylesheet">
+<link href="{{ "css/custom.css" | relURL }}" rel="stylesheet">
 
 <!-- Responsivity for older IE -->
 {{ `


### PR DESCRIPTION
## Summary
- Remove `?{{ now.Unix }}` timestamp query string from `custom.css` link
- The timestamp generated a unique URL on every Hugo build, which prevented browsers from ever caching the stylesheet
- After this fix, browsers will properly cache `custom.css` between visits

## Details
Hugo regenerates templates on every build, so `now.Unix` produced a new value each time. This defeated browser caching entirely for the custom stylesheet, causing unnecessary re-downloads on every page load.

## Test plan
- [x] Run `hugo` twice and confirm `custom.css` URL is stable (no changing query string)
- [x] Verify stylesheet still loads correctly in browser