### PR TITLE
Add generic BlogPosting and FAQPage JSON-LD structured data

### DIFF
--- a/layouts/partials/headers.html
+++ b/layouts/partials/headers.html
@@ -98,3 +98,7 @@
 {{ end }}
 <meta name="twitter:description" content="{{ $description_plain | truncate 200 }}">
 {{ with .Param "twitter_author" }}<meta name="twitter:creator" content="@{{ . }}">{{ end }}
+
+<!-- JSON-LD Structured Data -->
+{{ if and (eq .Section "blog") .IsPage }}{{ partial "json-ld-blog.html" . }}{{ end }}
+{{ if .Params.faq }}{{ partial "json-ld-faq.html" . }}{{ end }}

--- a/layouts/partials/json-ld-blog.html
+++ b/layouts/partials/json-ld-blog.html
@@ -1,0 +1,30 @@
+{{- $description := default .Site.Params.defaultDescription .Description | markdownify | plainify -}}
+{{- $image := .Params.banner | default .Site.Params.default_sharing_image -}}
+{{- $baseURL := .Site.BaseURL | strings.TrimRight "/" -}}
+{{- $orgName := .Site.Title -}}
+{{- with .Site.Params.organization }}{{ $orgName = .name | default $orgName }}{{ end -}}
+{{- $logo := .Site.Params.logo | default "" -}}
+{{- with .Site.Params.organization }}{{ $logo = .logo | default $logo }}{{ end -}}
+
+{{- $jsonLd := dict
+  "@context" "https://schema.org"
+  "@type" "BlogPosting"
+  "headline" .Title
+  "description" $description
+  "url" .Permalink
+  "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+  "author" (dict "@type" "Organization" "name" $orgName "url" $baseURL)
+  "publisher" (dict "@type" "Organization" "name" $orgName "logo" (dict "@type" "ImageObject" "url" (printf "%s/%s" $baseURL $logo)))
+-}}
+
+{{- with .Lastmod -}}
+{{- $jsonLd = merge $jsonLd (dict "dateModified" (.Format "2006-01-02T15:04:05Z07:00")) -}}
+{{- end -}}
+
+{{- if $image -}}
+{{- $jsonLd = merge $jsonLd (dict "image" (printf "%s/%s" $baseURL $image)) -}}
+{{- end -}}
+
+<script type="application/ld+json">
+{{ $jsonLd | jsonify | safeJS }}
+</script>

--- a/layouts/partials/json-ld-faq.html
+++ b/layouts/partials/json-ld-faq.html
@@ -1,0 +1,20 @@
+{{- with .Params.faq -}}
+{{- $questions := slice -}}
+{{- range . -}}
+{{- $questions = $questions | append (dict
+  "@type" "Question"
+  "name" .question
+  "acceptedAnswer" (dict "@type" "Answer" "text" .answer)
+) -}}
+{{- end -}}
+
+{{- $jsonLd := dict
+  "@context" "https://schema.org"
+  "@type" "FAQPage"
+  "mainEntity" $questions
+-}}
+
+<script type="application/ld+json">
+{{ $jsonLd | jsonify | safeJS }}
+</script>
+{{- end -}}


### PR DESCRIPTION
## Summary
- Adds `json-ld-blog.html` partial: auto-generates [BlogPosting](https://schema.org/BlogPosting) schema for blog posts
- Adds `json-ld-faq.html` partial: auto-generates [FAQPage](https://schema.org/FAQPage) schema from front matter
- Both are included automatically via `headers.html` — no configuration needed

## BlogPosting
Automatically injected on any page where `section == "blog"`. Uses standard Hugo variables (`.Title`, `.Permalink`, `.Date`, `.Lastmod`, `.Description`) and falls back to site params for org name and logo.

## FAQPage
Driven by front matter. Any page can opt in by adding `faq` entries:

```toml
[[faq]]
question = "How does this work?"
answer = "It generates FAQ rich results in Google."
```

## Test plan
- [x] Create a blog post and verify BlogPosting JSON-LD appears in page source
- [x] Create a page with `[[faq]]` front matter and verify FAQPage JSON-LD appears
- [x] Validate output with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [x] Verify pages without blog/faq have no extra JSON-LD