### PR TITLE
Add config-driven GTM, Meta Pixel, and Facebook verification

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -408,6 +408,11 @@ pluralizelisttitles = false
     latitude = "-12.043333"
     longitude = "-77.028333"
 
+    # Tracking & Verification (optional)
+    # facebook_domain_verification = "your-verification-code"
+    # meta_pixel_id = "your-meta-pixel-id"
+    # gtm_id = "GTM-XXXXXXX"
+
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "default"
 

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -8,6 +8,8 @@
 
   <body>
 
+    {{ partial "gtm-body.html" . }}
+
     <div id="all">
 
         {{ partial "top.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,6 +8,8 @@
 
   <body>
 
+    {{ partial "gtm-body.html" . }}
+
     <div id="all">
 
         {{ partial "top.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,6 +8,8 @@
 
   <body>
 
+    {{ partial "gtm-body.html" . }}
+
     <div id="all">
 
         {{ partial "top.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,8 @@
 
   <body>
 
+    {{ partial "gtm-body.html" . }}
+
     <div id="all">
 
         {{ partial "top.html" . }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -8,6 +8,8 @@
 
   <body>
 
+    {{ partial "gtm-body.html" . }}
+
     <div id="all">
         {{ partial "top.html" . }}
 

--- a/layouts/partials/facebook-verification.html
+++ b/layouts/partials/facebook-verification.html
@@ -1,0 +1,3 @@
+{{- with .Site.Params.facebook_domain_verification -}}
+<meta name="facebook-domain-verification" content="{{ . }}" />
+{{- end -}}

--- a/layouts/partials/gtm-body.html
+++ b/layouts/partials/gtm-body.html
@@ -1,0 +1,6 @@
+{{- with .Site.Params.gtm_id -}}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}" height="0" width="0"
+        style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{- end -}}

--- a/layouts/partials/gtm-head.html
+++ b/layouts/partials/gtm-head.html
@@ -1,0 +1,12 @@
+{{- with .Site.Params.gtm_id -}}
+<!-- Google Tag Manager -->
+<script>(function (w, d, s, l, i) {
+        w[l] = w[l] || []; w[l].push({
+            'gtm.start':
+                new Date().getTime(), event: 'gtm.js'
+        }); var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', '{{ . }}');</script>
+<!-- End Google Tag Manager -->
+{{- end -}}

--- a/layouts/partials/headers.html
+++ b/layouts/partials/headers.html
@@ -98,3 +98,8 @@
 {{ end }}
 <meta name="twitter:description" content="{{ $description_plain | truncate 200 }}">
 {{ with .Param "twitter_author" }}<meta name="twitter:creator" content="@{{ . }}">{{ end }}
+
+<!-- Tracking & Verification -->
+{{ partial "facebook-verification.html" . }}
+{{ partial "meta-pixel-head.html" . }}
+{{ partial "gtm-head.html" . }}

--- a/layouts/partials/meta-pixel-head.html
+++ b/layouts/partials/meta-pixel-head.html
@@ -1,0 +1,21 @@
+{{- with .Site.Params.meta_pixel_id -}}
+<!-- Meta Pixel Code -->
+<script>
+    !function (f, b, e, v, n, t, s) {
+        if (f.fbq) return; n = f.fbq = function () {
+            n.callMethod ?
+                n.callMethod.apply(n, arguments) : n.queue.push(arguments)
+        };
+        if (!f._fbq) f._fbq = n; n.push = n; n.loaded = !0; n.version = '2.0';
+        n.queue = []; t = b.createElement(e); t.async = !0;
+        t.src = v; s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s)
+    }(window, document, 'script',
+        'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '{{ . }}');
+    fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id={{ . }}&ev=PageView&noscript=1" /></noscript>
+<!-- End Meta Pixel Code -->
+{{- end -}}


### PR DESCRIPTION
## Summary
Adds optional, config-driven support for three common tracking/verification tools:

- **Google Tag Manager** (`gtm_id`) — head script + body noscript fallback
- **Meta/Facebook Pixel** (`meta_pixel_id`) — tracking pixel with noscript fallback  
- **Facebook Domain Verification** (`facebook_domain_verification`) — meta tag

All are opt-in: if the param is not set, nothing is rendered.

## Configuration
Add any combination to `config.toml` / `hugo.toml`:

```toml
[params]
    facebook_domain_verification = "your-verification-code"
    meta_pixel_id = "your-meta-pixel-id"
    gtm_id = "GTM-XXXXXXX"
```

## Files changed
- 4 new partials: `facebook-verification.html`, `gtm-head.html`, `gtm-body.html`, `meta-pixel-head.html`
- `headers.html`: includes head-level partials
- All 5 layout files (`index`, `single`, `list`, `page/single`, `404`): GTM body noscript after `<body>`
- `exampleSite/hugo.toml`: commented-out example config

## Test plan
- [ ] Run example site without params — verify no tracking code in output
- [x] Add `gtm_id` and verify GTM script in `<head>` and noscript after `<body>`
- [x] Add `meta_pixel_id` and verify pixel code in `<head>`
- [x] Add `facebook_domain_verification` and verify meta tag in `<head>`