### PR TITLE
Fix deprecation warning (hugo 0.157.0)

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -446,7 +446,7 @@ pluralizelisttitles = false
     googleRecaptchaKey = "site_key_for_google_recaptcha"
 
     about_us = "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>"
-    copyright = "Copyright (c) 2015 - 2016, YourCompany; all rights reserved."
+    copyright = "Copyright (c) 2015 - 2026, YourCompany; all rights reserved."
 
     # Format dates with Go's time formatting
     date_format = "January 2, 2006"

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -1,6 +1,6 @@
 {{ if default true .Site.Params.CarouselHomepage.enable }}
-{{ if isset .Site.Data "carousel" }}
-{{ if gt (len .Site.Data.carousel) 0 }}
+{{ if isset hugo.Data "carousel" }}
+{{ if gt (len hugo.Data.carousel) 0 }}
 <section>
     <div class="home-carousel">
         <div class="dark-mask"></div>
@@ -9,7 +9,7 @@
                 data-autoplay="{{ default true .Site.Params.CarouselHomepage.auto_play }}"
                 data-slide-speed="{{ default 2000 .Site.Params.CarouselHomepage.slide_speed }}"
                 data-pagination-speed="{{ default 1000 .Site.Params.CarouselHomepage.pagination_speed }}">
-                {{ range sort .Site.Data.carousel "weight" }}
+                {{ range sort hugo.Data.carousel "weight" }}
                 <div class="item">
                     {{ if .href }}
                     <a href="{{ .href }}" target="_blank" title="{{ .title | safeHTML }}">

--- a/layouts/partials/clients.html
+++ b/layouts/partials/clients.html
@@ -1,7 +1,7 @@
 {{ if isset .Site.Params "clients" }}
 {{ if .Site.Params.clients.enable }}
-{{ if isset .Site.Data "clients" }}
-{{ if gt (len .Site.Data.clients) 0 }}
+{{ if isset hugo.Data "clients" }}
+{{ if gt (len hugo.Data.clients) 0 }}
 <section class="bar background-gray no-mb">
     <div class="container">
         <div class="row">
@@ -19,7 +19,7 @@
                     data-autoplay="{{ default false .Site.Params.CarouselCustomers.auto_play }}"
                     data-slide-speed="{{ default 2000 .Site.Params.CarouselCustomers.slide_speed }}"
                     data-pagination-speed="{{ default 1000 .Site.Params.CarouselCustomers.pagination_speed }}">
-                    {{ range .Site.Data.clients }}
+                    {{ range hugo.Data.clients }}
                     <li class="item" title="{{ .name }}">
                         {{ if .url }}
                           <a href="{{ .url }}" target="_blank">

--- a/layouts/partials/features.html
+++ b/layouts/partials/features.html
@@ -1,11 +1,11 @@
 {{ if isset .Site.Params "features" }}
 {{ if .Site.Params.features.enable }}
-{{ if isset .Site.Data "features" }}
-{{ if gt (len .Site.Data.features) 0 }}
+{{ if isset hugo.Data "features" }}
+{{ if gt (len hugo.Data.features) 0 }}
 <section class="bar background-white">
     <div class="container">
         {{ $elements := default 3 .Site.Params.features.cols }}
-        {{ $features := sort .Site.Data.features "weight" }}
+        {{ $features := sort hugo.Data.features "weight" }}
 
         {{ $total_rows := div (len $features) $elements }}
 

--- a/layouts/partials/testimonials.html
+++ b/layouts/partials/testimonials.html
@@ -1,7 +1,7 @@
 {{ if isset .Site.Params "testimonials" }}
 {{ if .Site.Params.testimonials.enable }}
-{{ if isset .Site.Data "testimonials" }}
-{{ if gt (len .Site.Data.testimonials) 0 }}
+{{ if isset hugo.Data "testimonials" }}
+{{ if gt (len hugo.Data.testimonials) 0 }}
 <section class="bar background-pentagon no-mb">
     <div class="container">
         <div class="row">
@@ -21,7 +21,7 @@
                     data-autoplay="{{ default false .Site.Params.CarouselTestimonials.auto_play }}"
                     data-slide-speed="{{ default 2000 .Site.Params.CarouselTestimonials.slide_speed }}"
                     data-pagination-speed="{{ default 1000 .Site.Params.CarouselTestimonials.pagination_speed }}">
-                    {{ range .Site.Data.testimonials }}
+                    {{ range hugo.Data.testimonials }}
                     <li class="item">
                         <div class="testimonial same-height-always">
                             <div class="text">


### PR DESCRIPTION
When running example site with latest hugo version 0.157.0, a deprecation warning is shown:

```
INFO  deprecated: .Site.Data was deprecated in Hugo v0.156.0 and will be removed in a future release.
Use hugo.Data instead.
```

This PR fixes this issue.

**Note**: This PR raises the minimum required hugo version to 0.156.0, so you may want to wait for a while until including this fix.